### PR TITLE
Support rpcserver & fix invoke_method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,11 +73,13 @@ pub mod rpc {
     mod rpcclient;
     mod rpcmapper;
     mod rpcresult;
+    mod rpcserver;
 
     pub use calloptions::*;
     pub use rpcclient::*;
     pub use rpcmapper::*;
     pub use rpcresult::*;
+    pub use rpcserver::*;
 }
 
 pub mod transport {

--- a/src/rpc/rpcclient.rs
+++ b/src/rpc/rpcclient.rs
@@ -41,6 +41,7 @@ pub trait RpcClient {
     ///
     /// Returns a Future with the result or error.
     async fn invoke_method(
+        &self,
         topic: UUri,
         payload: UPayload,
         attributes: UAttributes,

--- a/src/rpc/rpcserver.rs
+++ b/src/rpc/rpcserver.rs
@@ -1,0 +1,53 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use async_trait::async_trait;
+
+use crate::uprotocol::{UMessage, UStatus, UUri};
+
+/// `RpcServer` is an interface called by uServices to register method listeners for
+/// incoming RPC requests from clients.
+/// TODO: Add uProtocol spec in the future
+#[async_trait]
+pub trait RpcServer {
+    /// Register a listener for a particular method URI to be notified when requests
+    /// are sent against said method.
+    /// Note: Only one listener is allowed to be registered per method URI.
+    ///
+    /// # Arguments
+    /// * `method` - Resolved `UUri` indicating the method for which the listener is registered.
+    /// * `listener` - A boxed closure (or function pointer) that takes `Result<UMessage, UStatus>` as an argument and returns nothing.
+    ///                The closure is executed to process the data or handle the error for the method.
+    ///                It must be `Send`, `Sync` and `'static` to allow transfer across threads and a stable lifetime.
+    ///
+    /// # Returns
+    /// Asynchronously returns a `Result<String, UStatus>`.
+    /// On success, returns a `String` containing an identifier that can be used for unregistering the listener later.
+    /// On failure, returns `Err(UStatus)` with the appropriate failure information.
+    async fn register_rpc_listener(
+        &self,
+        method: UUri,
+        listener: Box<dyn Fn(Result<UMessage, UStatus>) + Send + Sync + 'static>,
+    ) -> Result<String, UStatus>;
+
+    /// Unregister an RPC listener for a given method Uri. Messages arriving on this method
+    /// will no longer be processed by this listener.
+    ///
+    /// # Arguments
+    /// * `method` - Resolved `UUri` for where the listener was registered to receive messages from.
+    /// * `listener` - Identifier of the listener that should be unregistered.
+    ///
+    /// # Returns
+    /// Returns () on success, otherwise an Err(UStatus) with the appropriate failure information.
+    async fn unregister_rpc_listener(&self, method: UUri, listener: &str) -> Result<(), UStatus>;
+}

--- a/src/rpc/rpcserver.rs
+++ b/src/rpc/rpcserver.rs
@@ -17,7 +17,9 @@ use crate::uprotocol::{UMessage, UStatus, UUri};
 
 /// `RpcServer` is an interface called by uServices to register method listeners for
 /// incoming RPC requests from clients.
-/// TODO: Add uProtocol spec in the future
+///
+/// For more details, please refer to the
+/// [RpcServer Specifications](https://github.com/eclipse-uprotocol/uprotocol-spec/blob/main/up-l2/README.adoc).
 #[async_trait]
 pub trait RpcServer {
     /// Register a listener for a particular method URI to be notified when requests

--- a/src/transport/validator/uattributesvalidator.rs
+++ b/src/transport/validator/uattributesvalidator.rs
@@ -394,7 +394,7 @@ impl UAttributesValidator for RequestValidator {
     /// Returns a `ValidationResult` that is success or failed with a failure message.
     fn validate_sink(&self, attributes: &UAttributes) -> Result<(), ValidationError> {
         if let Some(sink) = &attributes.sink {
-            UriValidator::validate_rpc_response(sink)
+            UriValidator::validate_rpc_method(sink)
         } else {
             Err(ValidationError::new("Missing Sink"))
         }
@@ -470,7 +470,7 @@ impl UAttributesValidator for ResponseValidator {
     /// Returns a `ValidationResult` that is success or failed with a failure message.
     fn validate_sink(&self, attributes: &UAttributes) -> Result<(), ValidationError> {
         if let Some(sink) = &attributes.sink {
-            UriValidator::validate_rpc_method(sink)
+            UriValidator::validate_rpc_response(sink)
         } else {
             Err(ValidationError::new("Missing Sink"))
         }


### PR DESCRIPTION
The PR is mainly for
1. Support RPCServer trait similar to [the PR](https://github.com/eclipse-uprotocol/up-java/pull/60)
2. Add the missing `&self` to the `invoke_method`
3. Fix the wrong validation function for `validate_sink`
