### PR TITLE
Use rust-protobuf instead of prost

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,24 +34,22 @@ rust-version = "1.66"
 version = "0.1.5"
 
 [dependencies]
-async-trait = "0.1"
-byteorder = "1.4"
-bytes = "1.4"
-chrono = "0.4"
+async-trait = { version = "0.1" }
+bytes = { version = "1.5" }
+chrono = { version = "0.4" }
 cloudevents-sdk = { version = "0.7" }
-prost = "0.12"
-prost-types = "0.12"
-rand = "0.8"
-regex = "1"
+protobuf = { version = "3.3" }
+rand = { version = "0.8" }
+regex = { version = "1.10" }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-url = "2"
-uuid = { version = "1.6", features = ["v8"] }
+serde_json = { version = "1.0" }
+url = { version = "2.5" }
+uuid = { version = "1.7", features = ["v8"] }
 
 [build-dependencies]
-prost-build = { version = "0.12" }
-protoc-bin-vendored = { version = "3" }
-ureq = "2.7"
+protobuf-codegen = { version = "3.3" }
+protoc-bin-vendored = { version = "3.0" }
+ureq = { version = "2.7" }
 
 [dev-dependencies]
-test-case = "3.3"
+test-case = { version = "3.3" }

--- a/build.rs
+++ b/build.rs
@@ -11,94 +11,99 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use prost_build::Config;
 use std::env;
 use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 
-fn main() -> std::io::Result<()> {
-    // use vendored protoc instead of relying on user provided protobuf installation
-    std::env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path().unwrap());
+const UPROTOCOL_BASE_URI: &str = "https://raw.githubusercontent.com/eclipse-uprotocol/uprotocol-core-api/uprotocol-core-api-1.5.5/uprotocol";
 
-    if let Err(err) = get_and_build_protos(
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    get_and_build_protos(
         &[
             // cloudevent proto definitions
             "https://raw.githubusercontent.com/cloudevents/spec/main/cloudevents/formats/cloudevents.proto", 
+        ],
+        "cloudevents",
+    )?;
 
+    get_and_build_protos(
+        &[
             // uProtocol-project proto definitions
-            "https://raw.githubusercontent.com/eclipse-uprotocol/uprotocol-core-api/uprotocol-core-api-1.5.3/src/main/proto/uuid.proto",
-            "https://raw.githubusercontent.com/eclipse-uprotocol/uprotocol-core-api/uprotocol-core-api-1.5.3/src/main/proto/uri.proto",
-            "https://raw.githubusercontent.com/eclipse-uprotocol/uprotocol-core-api/uprotocol-core-api-1.5.3/src/main/proto/uattributes.proto",
-            "https://raw.githubusercontent.com/eclipse-uprotocol/uprotocol-core-api/uprotocol-core-api-1.5.3/src/main/proto/upayload.proto",
-            "https://raw.githubusercontent.com/eclipse-uprotocol/uprotocol-core-api/uprotocol-core-api-1.5.3/src/main/proto/umessage.proto",
-            "https://raw.githubusercontent.com/eclipse-uprotocol/uprotocol-core-api/uprotocol-core-api-1.5.3/src/main/proto/ustatus.proto",
-
+            format!("{}/uuid.proto", UPROTOCOL_BASE_URI).as_str(),
+            format!("{}/uri.proto", UPROTOCOL_BASE_URI).as_str(),
+            format!("{}/uattributes.proto", UPROTOCOL_BASE_URI).as_str(),
+            format!("{}/upayload.proto", UPROTOCOL_BASE_URI).as_str(),
+            format!("{}/umessage.proto", UPROTOCOL_BASE_URI).as_str(),
+            format!("{}/ustatus.proto", UPROTOCOL_BASE_URI).as_str(),
             // not used in the SDK yet, but for completeness sake
-            "https://raw.githubusercontent.com/eclipse-uprotocol/uprotocol-core-api/uprotocol-core-api-1.5.3/src/main/proto/file.proto",
-            "https://raw.githubusercontent.com/eclipse-uprotocol/uprotocol-core-api/uprotocol-core-api-1.5.3/src/main/proto/uprotocol_options.proto",
-            "https://raw.githubusercontent.com/eclipse-uprotocol/uprotocol-core-api/uprotocol-core-api-1.5.3/src/main/proto/core/udiscovery/v3/udiscovery.proto",
-            "https://raw.githubusercontent.com/eclipse-uprotocol/uprotocol-core-api/uprotocol-core-api-1.5.3/src/main/proto/core/usubscription/v3/usubscription.proto",
-            "https://raw.githubusercontent.com/eclipse-uprotocol/uprotocol-core-api/uprotocol-core-api-1.5.3/src/main/proto/core/utwin/v1/utwin.proto",
-        ]
-    ) {
-        let error_message = format!("Failed to fetch and build protobuf file: {err:?}");
-        return Err(std::io::Error::new(std::io::ErrorKind::Other, error_message));
-    }
+            format!("{}/file.proto", UPROTOCOL_BASE_URI).as_str(),
+            format!("{}/uprotocol_options.proto", UPROTOCOL_BASE_URI).as_str(),
+            format!("{}/core/udiscovery/v3/udiscovery.proto", UPROTOCOL_BASE_URI).as_str(),
+            format!(
+                "{}/core/usubscription/v3/usubscription.proto",
+                UPROTOCOL_BASE_URI
+            )
+            .as_str(),
+            format!("{}/core/utwin/v1/utwin.proto", UPROTOCOL_BASE_URI).as_str(),
+        ],
+        "uprotocol",
+    )?;
 
     Ok(())
 }
 
 // Fetch protobuf definitions from `url`, and build them with prost_build
-fn get_and_build_protos(urls: &[&str]) -> core::result::Result<(), Box<dyn std::error::Error>> {
+fn get_and_build_protos(
+    urls: &[&str],
+    output_folder: &str,
+) -> core::result::Result<(), Box<dyn std::error::Error>> {
     let out_dir = env::var_os("OUT_DIR").unwrap();
+    let proto_folder = Path::new(&out_dir).join("proto");
     let mut proto_files = Vec::new();
 
     for url in urls {
         // Extract filename from the URL
         let filename = url.rsplit('/').next().unwrap_or_default();
-        let dest_path = Path::new(&out_dir).join(filename);
+        let dest_path = proto_folder.join(filename);
 
         // Download the .proto file
-        if let Err(err) = download_and_write_file(url, filename) {
-            panic!("Failed to download and write file: {err:?}");
-        }
+        download_and_write_file(url, &dest_path)?;
         proto_files.push(dest_path);
     }
 
-    // Compile all .proto files together
-    let mut config = Config::new();
-
-    // Some proto files contain comments that will be interpreted as rustdoc comments (and fail to compile)
-    config.disable_comments(["."]);
-
-    config.compile_protos(&proto_files, &[&out_dir])?;
+    protobuf_codegen::Codegen::new()
+        .protoc()
+        // use vendored protoc instead of relying on user provided protobuf installation
+        .protoc_path(&protoc_bin_vendored::protoc_bin_path().unwrap())
+        .include(proto_folder)
+        .inputs(proto_files)
+        .cargo_out_dir(output_folder)
+        .run_from_script();
 
     Ok(())
 }
 
-// Retreives a file from `url` (from GitHub, for instance) and places it in the build directory (`OUT_DIR`) with the name
+// Retrieves a file from `url` (from GitHub, for instance) and places it in the build directory (`OUT_DIR`) with the name
 // provided by `destination` parameter.
 fn download_and_write_file(
     url: &str,
-    destination: &str,
+    dest_path: &PathBuf,
 ) -> core::result::Result<(), Box<dyn std::error::Error>> {
     // Send a GET request to the URL
-    let resp = ureq::get(url).call();
 
-    match resp {
-        Err(error) => Err(Box::new(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            error.to_string(),
-        ))),
+    match ureq::get(url).call() {
+        Err(error) => Err(Box::from(error)),
         Ok(response) => {
-            let out_dir = env::var_os("OUT_DIR").unwrap();
-            let dest_path = Path::new(&out_dir).join(destination);
+            if let Some(parent_path) = dest_path.parent() {
+                std::fs::create_dir_all(parent_path)?;
+            }
             let mut out_file = fs::File::create(dest_path)?;
 
             // Write the response body directly to the file
-            let _ = std::io::copy(&mut response.into_reader(), &mut out_file);
-
-            Ok(())
+            std::io::copy(&mut response.into_reader(), &mut out_file)
+                .map(|_| ())
+                .map_err(Box::from)
         }
     }
 }

--- a/src/cloudevent/builder/ucloudeventbuilder.rs
+++ b/src/cloudevent/builder/ucloudeventbuilder.rs
@@ -18,7 +18,7 @@ use protobuf::Enum;
 use url::{ParseError, Url};
 
 use crate::cloudevent::datamodel::UCloudEventAttributes;
-use crate::uprotocol::uattributes::UMessageType;
+use crate::uprotocol::UMessageType;
 use crate::uuid::builder::UUIDv8Builder;
 
 pub struct UCloudEventBuilder;
@@ -425,9 +425,7 @@ mod tests {
 
     use super::*;
     use crate::cloudevent::builder::UCloudEventUtils;
-    use crate::uprotocol::uattributes::UPriority;
-    use crate::uprotocol::uri::{UAuthority, UEntity, UResource, UUri};
-    use crate::uprotocol::ustatus::UCode;
+    use crate::uprotocol::{UAuthority, UCode, UEntity, UPriority, UResource, UUri};
     use crate::uri::builder::resourcebuilder::UResourceBuilder;
     use crate::uri::serializer::{LongUriSerializer, UriSerializer};
 

--- a/src/cloudevent/builder/ucloudeventbuilder.rs
+++ b/src/cloudevent/builder/ucloudeventbuilder.rs
@@ -13,11 +13,12 @@
 
 use chrono::Utc;
 use cloudevents::{Event, EventBuilder, EventBuilderV10};
-use prost_types::Any;
+use protobuf::well_known_types::any::Any;
+use protobuf::Enum;
 use url::{ParseError, Url};
 
 use crate::cloudevent::datamodel::UCloudEventAttributes;
-use crate::uprotocol::UMessageType;
+use crate::uprotocol::uattributes::UMessageType;
 use crate::uuid::builder::UUIDv8Builder;
 
 pub struct UCloudEventBuilder;
@@ -60,20 +61,21 @@ impl UCloudEventBuilder {
     /// # Example
     ///
     /// ```rust
-    /// use prost_types::Any;
+    /// use protobuf::well_known_types::any::Any;
     /// use uprotocol_sdk::cloudevent::datamodel::{UCloudEventAttributes};
     /// use uprotocol_sdk::cloudevent::builder::UCloudEventBuilder;
-    /// use uprotocol_sdk::uprotocol::UPriority;
+    /// use uprotocol_sdk::uprotocol::uattributes::UPriority;
     ///
     /// let rpc_uri = "http://myapp.com/rpc";
     /// let service_method_uri = ":/body.access/1/rpc.UpdateDoor";
     /// let proto_payload = Any {
     ///     type_url: "type.googleapis.com/google.protobuf.StringValue".to_string(),
     ///     value: vec![104, 101, 108, 108, 111],  // 'hello' in ASCII
+    ///     ..Default::default()
     /// };
     /// let attributes = UCloudEventAttributes {
     ///     ttl: Some(60),
-    ///     priority: Some(UPriority::UpriorityCs0),
+    ///     priority: Some(UPriority::UPRIORITY_CS0),
     ///     hash: Some("123456".to_string()),
     ///     token: Some("abcdef".to_string()),
     /// };
@@ -94,7 +96,7 @@ impl UCloudEventBuilder {
             attributes,
         )
         .extension("sink", service_method_uri)
-        .ty(UMessageType::UmessageTypeRequest)
+        .ty(UMessageType::UMESSAGE_TYPE_REQUEST)
         .build();
 
         bce.unwrap()
@@ -123,7 +125,7 @@ impl UCloudEventBuilder {
     /// ```
     /// use uprotocol_sdk::cloudevent::builder::UCloudEventBuilder;
     /// use uprotocol_sdk::cloudevent::datamodel::UCloudEventAttributes;
-    /// use prost_types::Any;
+    /// use protobuf::well_known_types::any::Any;
     ///
     /// let rpc_uri = "https://example.com/rpc";
     /// let service_method_uri = "https://example.com/service_method";
@@ -131,6 +133,7 @@ impl UCloudEventBuilder {
     /// let proto_payload = &Any {
     ///     type_url: "type".to_string(),
     ///     value: vec![],
+    ///     ..Default::default()
     /// };
     /// let attributes = &UCloudEventAttributes::default();
     ///
@@ -158,7 +161,7 @@ impl UCloudEventBuilder {
         )
         .extension("sink", rpc_uri)
         .extension("reqid", request_id)
-        .ty(UMessageType::UmessageTypeResponse)
+        .ty(UMessageType::UMESSAGE_TYPE_RESPONSE)
         .build();
 
         bce.unwrap()
@@ -187,7 +190,7 @@ impl UCloudEventBuilder {
     /// ```rust
     /// use uprotocol_sdk::cloudevent::builder::UCloudEventBuilder;
     /// use uprotocol_sdk::cloudevent::datamodel::UCloudEventAttributes;
-    /// use prost_types::Any;
+    /// use protobuf::well_known_types::any::Any;
     ///
     /// let application_uri = "http://myapplication.com/rpc";
     /// let service_method_uri = ":/body.access/1/rpc.UpdateDoor";
@@ -224,7 +227,7 @@ impl UCloudEventBuilder {
         .extension("sink", rpc_uri)
         .extension("reqid", request_id)
         .extension("commstatus", i64::from(communication_status))
-        .ty(UMessageType::UmessageTypeResponse)
+        .ty(UMessageType::UMESSAGE_TYPE_RESPONSE)
         .build();
 
         bce.unwrap()
@@ -251,7 +254,7 @@ impl UCloudEventBuilder {
     /// ```rust
     /// use uprotocol_sdk::cloudevent::builder::UCloudEventBuilder;
     /// use uprotocol_sdk::cloudevent::datamodel::UCloudEventAttributes;
-    /// use prost_types::Any;
+    /// use protobuf::well_known_types::any::Any;
     ///
     /// let source = "http://myapplication.com/topic";
     /// let attributes = UCloudEventAttributes::default(); // Populate with real data
@@ -271,7 +274,7 @@ impl UCloudEventBuilder {
             &payload.type_url,
             attributes,
         )
-        .ty(UMessageType::UmessageTypePublish)
+        .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
         .build();
 
         bce.unwrap()
@@ -301,7 +304,7 @@ impl UCloudEventBuilder {
     /// ```rust
     /// use uprotocol_sdk::cloudevent::builder::UCloudEventBuilder;
     /// use uprotocol_sdk::cloudevent::datamodel::UCloudEventAttributes;
-    /// use prost_types::Any;
+    /// use protobuf::well_known_types::any::Any;
     ///
     /// let source = "http://myapplication.com/topic";
     /// let sink = "http://myapplication.com/destination";
@@ -329,7 +332,7 @@ impl UCloudEventBuilder {
             attributes,
         )
         .extension("sink", sink)
-        .ty(UMessageType::UmessageTypePublish)
+        .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
         .build();
 
         bce.unwrap()
@@ -357,7 +360,7 @@ impl UCloudEventBuilder {
     /// # use cloudevents::{Event, EventBuilder, EventBuilderV10};
     /// # use uprotocol_sdk::cloudevent::builder::UCloudEventBuilder;
     /// # use uprotocol_sdk::cloudevent::datamodel::UCloudEventAttributes;
-    /// # use prost_types::Any;
+    /// # use protobuf::well_known_types::any::Any;
     ///
     /// let id = "unique_id";
     /// let source = "source_url";
@@ -395,7 +398,7 @@ impl UCloudEventBuilder {
             eb = eb.extension("ttl", i64::from(ttl_value));
         }
         if let Some(priority_value) = &attributes.priority {
-            eb = eb.extension("priority", priority_value.as_str_name());
+            eb = eb.extension("priority", priority_value.value() as i64);
         }
         if let Some(hash_value) = &attributes.hash {
             eb = eb.extension("hash", hash_value.clone());
@@ -422,7 +425,9 @@ mod tests {
 
     use super::*;
     use crate::cloudevent::builder::UCloudEventUtils;
-    use crate::uprotocol::{Remote, UAuthority, UCode, UEntity, UPriority, UResource, UUri};
+    use crate::uprotocol::uattributes::UPriority;
+    use crate::uprotocol::uri::{UAuthority, UEntity, UResource, UUri};
+    use crate::uprotocol::ustatus::UCode;
     use crate::uri::builder::resourcebuilder::UResourceBuilder;
     use crate::uri::serializer::{LongUriSerializer, UriSerializer};
 
@@ -434,11 +439,13 @@ mod tests {
             entity: Some(UEntity {
                 name: "body.access".to_string(),
                 ..Default::default()
-            }),
+            })
+            .into(),
             resource: Some(UResource {
                 name: "door".to_string(),
                 ..Default::default()
-            }),
+            })
+            .into(),
             ..Default::default()
         };
 
@@ -447,7 +454,7 @@ mod tests {
 
         let ucloud_event_attributes = UCloudEventAttributes::builder()
             .with_hash("somehash".to_string())
-            .with_priority(UPriority::UpriorityCs0)
+            .with_priority(UPriority::UPRIORITY_CS0)
             .with_ttl(3)
             .with_token("someOAuthToken".to_string())
             .build();
@@ -459,7 +466,7 @@ mod tests {
             &proto_payload.type_url,
             &ucloud_event_attributes,
         )
-        .ty(UMessageType::UmessageTypePublish)
+        .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
         .build()
         .unwrap();
 
@@ -467,7 +474,7 @@ mod tests {
         assert_eq!("testme", cloud_event.id());
         assert_eq!(source, cloud_event.source().to_string());
         assert_eq!(
-            UMessageType::UmessageTypePublish.to_string(),
+            UMessageType::UMESSAGE_TYPE_PUBLISH.to_string(),
             cloud_event.ty()
         );
         assert!(!cloud_event
@@ -489,8 +496,8 @@ mod tests {
             cloud_event.extension("hash").unwrap().to_string()
         );
         assert_eq!(
-            UPriority::UpriorityCs0.as_str_name(),
-            cloud_event.extension("priority").unwrap().to_string()
+            UPriority::UPRIORITY_CS0,
+            UCloudEventUtils::get_priority(&cloud_event).unwrap()
         );
         assert_eq!("3", cloud_event.extension("ttl").unwrap().to_string());
         assert_eq!(
@@ -509,11 +516,13 @@ mod tests {
             entity: Some(UEntity {
                 name: "body.access".to_string(),
                 ..Default::default()
-            }),
+            })
+            .into(),
             resource: Some(UResource {
                 name: "door".to_string(),
                 ..Default::default()
-            }),
+            })
+            .into(),
             ..Default::default()
         };
         let source = uri.to_string();
@@ -526,7 +535,7 @@ mod tests {
             &proto_payload.type_url,
             &ucloud_event_attributes,
         )
-        .ty(UMessageType::UmessageTypePublish)
+        .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
         .build()
         .unwrap();
 
@@ -534,7 +543,7 @@ mod tests {
         assert_eq!("testme", cloud_event.id());
         assert_eq!(source, cloud_event.source().to_string());
         assert_eq!(
-            UMessageType::UmessageTypePublish.to_string(),
+            UMessageType::UMESSAGE_TYPE_PUBLISH.to_string(),
             cloud_event.ty()
         );
         assert!(!cloud_event
@@ -572,11 +581,13 @@ mod tests {
             entity: Some(UEntity {
                 name: "body.access".to_string(),
                 ..Default::default()
-            }),
+            })
+            .into(),
             resource: Some(UResource {
                 name: "door".to_string(),
                 ..Default::default()
-            }),
+            })
+            .into(),
             ..Default::default()
         };
         let source = uri.to_string();
@@ -587,7 +598,7 @@ mod tests {
         // additional attributes
         let ucloud_event_attributes = UCloudEventAttributes {
             hash: Some("somehash".to_string()),
-            priority: Some(UPriority::UpriorityCs0),
+            priority: Some(UPriority::UPRIORITY_CS0),
             ttl: Some(3),
             token: None,
         };
@@ -599,7 +610,7 @@ mod tests {
         assert!(!cloud_event.id().is_empty());
         assert_eq!(source, cloud_event.source().to_string());
         assert_eq!(
-            UMessageType::UmessageTypePublish.to_string(),
+            UMessageType::UMESSAGE_TYPE_PUBLISH.to_string(),
             cloud_event.ty()
         );
         assert!(!cloud_event
@@ -621,8 +632,8 @@ mod tests {
             cloud_event.extension("hash").unwrap().to_string()
         );
         assert_eq!(
-            UPriority::UpriorityCs0.as_str_name(),
-            cloud_event.extension("priority").unwrap().to_string()
+            UPriority::UPRIORITY_CS0,
+            UCloudEventUtils::get_priority(&cloud_event).unwrap()
         );
         assert_eq!(
             3,
@@ -641,11 +652,13 @@ mod tests {
             entity: Some(UEntity {
                 name: "body.access".to_string(),
                 ..Default::default()
-            }),
+            })
+            .into(),
             resource: Some(UResource {
                 name: "door".to_string(),
                 ..Default::default()
-            }),
+            })
+            .into(),
             ..Default::default()
         };
         let source = uri.to_string();
@@ -653,16 +666,21 @@ mod tests {
         // sink
         let sink_uri = UUri {
             authority: Some(UAuthority {
-                remote: Some(Remote::Name("com.gm.bo".into())),
-            }),
+                name: Some(String::from("com.gm.bo")),
+                ..Default::default()
+            })
+            .into(),
             entity: Some(UEntity {
                 name: "petapp".to_string(),
                 ..Default::default()
-            }),
+            })
+            .into(),
             resource: Some(UResource {
                 name: "OK".to_string(),
                 ..Default::default()
-            }),
+            })
+            .into(),
+            ..Default::default()
         };
         let sink = sink_uri.to_string();
 
@@ -672,7 +690,7 @@ mod tests {
         // additional attributes
         let ucloud_event_attributes = UCloudEventAttributes {
             hash: Some("somehash".to_string()),
-            priority: Some(UPriority::UpriorityCs2),
+            priority: Some(UPriority::UPRIORITY_CS2),
             ttl: Some(3),
             token: None,
         };
@@ -688,7 +706,7 @@ mod tests {
             .any(|(name, _value)| name.contains("sink")));
         assert_eq!(sink, cloud_event.extension("sink").unwrap().to_string());
         assert_eq!(
-            UMessageType::UmessageTypePublish.to_string(),
+            UMessageType::UMESSAGE_TYPE_PUBLISH.to_string(),
             cloud_event.ty()
         );
         assert_eq!(
@@ -707,8 +725,8 @@ mod tests {
             cloud_event.extension("hash").unwrap().to_string()
         );
         assert_eq!(
-            UPriority::UpriorityCs2.as_str_name(),
-            cloud_event.extension("priority").unwrap().to_string()
+            UPriority::UPRIORITY_CS2,
+            UCloudEventUtils::get_priority(&cloud_event).unwrap()
         );
         assert_eq!(
             3,
@@ -734,7 +752,7 @@ mod tests {
         // additional attributes
         let ucloud_event_attributes = UCloudEventAttributes {
             hash: Some("somehash".to_string()),
-            priority: Some(UPriority::UpriorityCs2),
+            priority: Some(UPriority::UPRIORITY_CS2),
             ttl: Some(3),
             token: Some("someOAuthToken".to_string()),
         };
@@ -762,8 +780,8 @@ mod tests {
             cloud_event.extension("hash").unwrap().to_string()
         );
         assert_eq!(
-            UPriority::UpriorityCs2.as_str_name(),
-            cloud_event.extension("priority").unwrap().to_string()
+            UPriority::UPRIORITY_CS2,
+            UCloudEventUtils::get_priority(&cloud_event).unwrap()
         );
         assert_eq!(
             3,
@@ -787,8 +805,9 @@ mod tests {
                 name: "petapp".to_string(),
                 version_major: Some(1),
                 ..Default::default()
-            }),
-            resource: Some(UResourceBuilder::for_rpc_response()),
+            })
+            .into(),
+            resource: Some(UResourceBuilder::for_rpc_response()).into(),
             ..Default::default()
         };
         let application_uri_for_rpc = LongUriSerializer::serialize(&rpc_uri).unwrap();
@@ -799,11 +818,13 @@ mod tests {
                 name: "body.access".to_string(),
                 version_major: Some(1),
                 ..Default::default()
-            }),
+            })
+            .into(),
             resource: Some(UResourceBuilder::for_rpc_request(
                 Some("UpdateDoor".into()),
                 None,
-            )),
+            ))
+            .into(),
             ..Default::default()
         };
         let service_method_uri = LongUriSerializer::serialize(&method_uri).unwrap();
@@ -814,7 +835,7 @@ mod tests {
         // additional attributes
         let ucloud_event_attributes = UCloudEventAttributes {
             hash: Some("somehash".to_string()),
-            priority: Some(UPriority::UpriorityCs2),
+            priority: Some(UPriority::UPRIORITY_CS2),
             ttl: Some(3),
             token: None,
         };
@@ -857,8 +878,8 @@ mod tests {
             cloud_event.extension("hash").unwrap().to_string()
         );
         assert_eq!(
-            UPriority::UpriorityCs2.as_str_name(),
-            cloud_event.extension("priority").unwrap().to_string()
+            UPriority::UPRIORITY_CS2,
+            UCloudEventUtils::get_priority(&cloud_event).unwrap()
         );
         assert_eq!(
             3,
@@ -882,8 +903,9 @@ mod tests {
                 name: "petapp".to_string(),
                 version_major: Some(1),
                 ..Default::default()
-            }),
-            resource: Some(UResourceBuilder::for_rpc_response()),
+            })
+            .into(),
+            resource: Some(UResourceBuilder::for_rpc_response()).into(),
             ..Default::default()
         };
         let application_uri_for_rpc = LongUriSerializer::serialize(&rpc_uri).unwrap();
@@ -894,11 +916,13 @@ mod tests {
                 name: "body.access".to_string(),
                 version_major: Some(1),
                 ..Default::default()
-            }),
+            })
+            .into(),
             resource: Some(UResourceBuilder::for_rpc_request(
                 Some("UpdateDoor".into()),
                 None,
-            )),
+            ))
+            .into(),
             ..Default::default()
         };
         let service_method_uri = LongUriSerializer::serialize(&method_uri).unwrap();
@@ -906,7 +930,7 @@ mod tests {
         // Additional attributes
         let ucloud_event_attributes = UCloudEventAttributes {
             hash: Some("somehash".to_string()),
-            priority: Some(UPriority::UpriorityCs2),
+            priority: Some(UPriority::UPRIORITY_CS2),
             ttl: Some(3),
             token: None,
         };
@@ -915,7 +939,7 @@ mod tests {
             &application_uri_for_rpc,
             &service_method_uri,
             "requestIdFromRequestCloudEvent",
-            UCode::InvalidArgument as u32,
+            UCode::INVALID_ARGUMENT as u32,
             &ucloud_event_attributes,
         );
 
@@ -945,15 +969,15 @@ mod tests {
             cloud_event.extension("hash").unwrap().to_string()
         );
         assert_eq!(
-            UPriority::UpriorityCs2.as_str_name(),
-            cloud_event.extension("priority").unwrap().to_string()
+            UPriority::UPRIORITY_CS2,
+            UCloudEventUtils::get_priority(&cloud_event).unwrap()
         );
         assert_eq!(
             3,
             UCloudEventUtils::extract_integer_value_from_extension(&cloud_event, "ttl").unwrap()
         );
         assert_eq!(
-            UCode::InvalidArgument as i32,
+            UCode::INVALID_ARGUMENT as i32,
             UCloudEventUtils::extract_integer_value_from_extension(&cloud_event, "commstatus")
                 .unwrap()
         );
@@ -974,7 +998,7 @@ mod tests {
         // Additional attributes
         let ucloud_event_attributes = UCloudEventAttributes {
             hash: Some("somehash".to_string()),
-            priority: Some(UPriority::UpriorityCs2),
+            priority: Some(UPriority::UPRIORITY_CS2),
             ttl: Some(3),
             token: None,
         };
@@ -983,7 +1007,7 @@ mod tests {
             &application_uri_for_rpc,
             &service_method_uri,
             "requestIdFromRequestCloudEvent",
-            UCode::InvalidArgument as u32,
+            UCode::INVALID_ARGUMENT as u32,
             &ucloud_event_attributes,
         );
 
@@ -1003,15 +1027,15 @@ mod tests {
             cloud_event.extension("hash").unwrap().to_string()
         );
         assert_eq!(
-            UPriority::UpriorityCs2.as_str_name(),
-            cloud_event.extension("priority").unwrap().to_string()
+            UPriority::UPRIORITY_CS2,
+            UCloudEventUtils::get_priority(&cloud_event).unwrap()
         );
         assert_eq!(
             3,
             UCloudEventUtils::extract_integer_value_from_extension(&cloud_event, "ttl").unwrap()
         );
         assert_eq!(
-            UCode::InvalidArgument as i32,
+            UCode::INVALID_ARGUMENT as i32,
             UCloudEventUtils::extract_integer_value_from_extension(&cloud_event, "commstatus")
                 .unwrap()
         );
@@ -1025,7 +1049,7 @@ mod tests {
         EventBuilderV10::new()
             .id("hello")
             .source("https://example.com")
-            .ty(UMessageType::UmessageTypePublish)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
             .data_with_schema(
                 "application/octet-stream",
                 "proto://type.googleapis.com/example.demo",
@@ -1054,9 +1078,10 @@ mod tests {
                 .to_string()
         };
 
-        prost_types::Any {
+        Any {
             type_url: schema,
             value: data_bytes,
+            ..Default::default()
         }
     }
 
@@ -1065,13 +1090,15 @@ mod tests {
             entity: Some(UEntity {
                 name: "body.access".to_string(),
                 ..Default::default()
-            }),
+            })
+            .into(),
             resource: Some(UResource {
                 name: "door".to_string(),
                 instance: Some("front_left".to_string()),
                 message: Some("Door".to_string()),
                 ..Default::default()
-            }),
+            })
+            .into(),
             ..Default::default()
         };
         LongUriSerializer::serialize(&uri).unwrap()

--- a/src/cloudevent/builder/ucloudeventutils.rs
+++ b/src/cloudevent/builder/ucloudeventutils.rs
@@ -18,8 +18,7 @@ use protobuf::well_known_types::any::Any;
 use protobuf::{Enum, Message, MessageFull};
 use std::time::SystemTime;
 
-use crate::uprotocol::uattributes::UPriority;
-use crate::uprotocol::{ustatus::UCode, uuid::UUID};
+use crate::uprotocol::{UCode, UPriority, UUID};
 
 /// Code to extract information from a `CloudEvent`
 #[derive(Debug)]
@@ -491,8 +490,7 @@ mod tests {
     use crate::cloudevent::builder::UCloudEventBuilder;
     use crate::cloudevent::datamodel::UCloudEventAttributes;
     use crate::cloudevents::CloudEvent;
-    use crate::uprotocol::uattributes::{UMessageType, UPriority};
-    use crate::uprotocol::uri::{UEntity, UResource, UUri};
+    use crate::uprotocol::{UEntity, UMessageType, UPriority, UResource, UUri};
     use crate::uri::serializer::{LongUriSerializer, UriSerializer};
     use crate::uuid::builder::UUIDv8Builder;
 

--- a/src/cloudevent/datamodel/ucloudeventattributes.rs
+++ b/src/cloudevent/datamodel/ucloudeventattributes.rs
@@ -13,7 +13,7 @@
 
 use std::fmt;
 
-use crate::uprotocol::UPriority;
+use crate::uprotocol::uattributes::UPriority;
 
 /// Specifies the properties that can configure the `UCloudEvent`.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -138,14 +138,14 @@ mod tests {
     fn test_hash_code_equals() {
         let attributes1 = UCloudEventAttributes::builder()
             .with_hash("somehash".to_string())
-            .with_priority(UPriority::UpriorityCs0)
+            .with_priority(UPriority::UPRIORITY_CS0)
             .with_ttl(3)
             .with_token("someOAuthToken".to_string())
             .build();
 
         let attributes2 = UCloudEventAttributes::builder()
             .with_hash("somehash".to_string())
-            .with_priority(UPriority::UpriorityCs0)
+            .with_priority(UPriority::UPRIORITY_CS0)
             .with_ttl(3)
             .with_token("someOAuthToken".to_string())
             .build();
@@ -154,28 +154,16 @@ mod tests {
     }
 
     #[test]
-    fn test_to_string() {
-        let attributes = UCloudEventAttributes::builder()
-            .with_hash("somehash".to_string())
-            .with_priority(UPriority::UpriorityCs0)
-            .with_ttl(3)
-            .with_token("someOAuthToken".to_string())
-            .build();
-
-        assert_eq!(attributes.to_string(), "UCloudEventAttributes { hash: Some(\"somehash\"), priority: Some(UpriorityCs0), ttl: Some(3), token: Some(\"someOAuthToken\") }");
-    }
-
-    #[test]
     fn test_create_valid() {
         let attributes = UCloudEventAttributes::builder()
             .with_hash("somehash".to_string())
-            .with_priority(UPriority::UpriorityCs6)
+            .with_priority(UPriority::UPRIORITY_CS6)
             .with_ttl(3)
             .with_token("someOAuthToken".to_string())
             .build();
 
         assert_eq!(attributes.hash(), Some("somehash"));
-        assert_eq!(attributes.priority(), Some(UPriority::UpriorityCs6));
+        assert_eq!(attributes.priority(), Some(UPriority::UPRIORITY_CS6));
         assert_eq!(attributes.ttl(), Some(3));
         assert_eq!(attributes.token(), Some("someOAuthToken"));
     }
@@ -220,7 +208,7 @@ mod tests {
         assert!(!attributes3.is_empty());
 
         let attributes4 = UCloudEventAttributes::builder()
-            .with_priority(UPriority::UpriorityUnspecified)
+            .with_priority(UPriority::UPRIORITY_UNSPECIFIED)
             .build();
 
         assert!(!attributes4.is_empty());

--- a/src/cloudevent/datamodel/ucloudeventattributes.rs
+++ b/src/cloudevent/datamodel/ucloudeventattributes.rs
@@ -13,7 +13,7 @@
 
 use std::fmt;
 
-use crate::uprotocol::uattributes::UPriority;
+use crate::uprotocol::UPriority;
 
 /// Specifies the properties that can configure the `UCloudEvent`.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]

--- a/src/cloudevent/serializer/cloudeventjsonserializer.rs
+++ b/src/cloudevent/serializer/cloudeventjsonserializer.rs
@@ -19,16 +19,11 @@ use crate::cloudevent::serializer::{CloudEventSerializer, SerializationError};
 pub struct CloudEventJsonSerializer;
 impl CloudEventSerializer for CloudEventJsonSerializer {
     fn serialize(&self, cloud_event: &CloudEvent) -> Result<Vec<u8>, SerializationError> {
-        match serde_json::to_vec(cloud_event) {
-            Ok(bytes) => Ok(bytes),
-            Err(error) => Err(SerializationError::new(error.to_string())),
-        }
+        serde_json::to_vec(cloud_event).map_err(|error| SerializationError::new(error.to_string()))
     }
 
     fn deserialize(&self, bytes: &[u8]) -> Result<CloudEvent, SerializationError> {
-        match serde_json::from_slice::<CloudEvent>(bytes) {
-            Ok(event) => Ok(event),
-            Err(error) => Err(SerializationError::new(error.to_string())),
-        }
+        serde_json::from_slice::<CloudEvent>(bytes)
+            .map_err(|error| SerializationError::new(error.to_string()))
     }
 }

--- a/src/cloudevent/serializer/cloudeventprotobufserializer.rs
+++ b/src/cloudevent/serializer/cloudeventprotobufserializer.rs
@@ -45,8 +45,7 @@ mod tests {
     use crate::cloudevent::datamodel::UCloudEventAttributesBuilder;
     use crate::cloudevent::serializer::cloudeventjsonserializer::CloudEventJsonSerializer;
     use crate::rpc::RpcMapper;
-    use crate::uprotocol::uattributes::{UMessageType, UPriority};
-    use crate::uprotocol::uri::{UAuthority, UEntity, UResource, UUri};
+    use crate::uprotocol::{UAuthority, UEntity, UMessageType, UPriority, UResource, UUri};
     use crate::uri::serializer::{LongUriSerializer, UriSerializer};
 
     #[test]

--- a/src/cloudevent/validator/cloudeventvalidator.rs
+++ b/src/cloudevent/validator/cloudeventvalidator.rs
@@ -16,8 +16,7 @@ use cloudevents::{AttributesReader, Event};
 
 use crate::cloudevent::builder::UCloudEventUtils;
 use crate::cloudevent::validator::ValidationError;
-use crate::uprotocol::uattributes::UMessageType;
-use crate::uprotocol::uri::{UResource, UUri};
+use crate::uprotocol::{UMessageType, UResource, UUri};
 use crate::uri::serializer::{LongUriSerializer, UriSerializer};
 use crate::uri::validator::UriValidator;
 
@@ -543,8 +542,7 @@ impl std::fmt::Display for ResponseValidator {
 mod tests {
     use crate::cloudevent::builder::UCloudEventBuilder;
     use crate::cloudevent::datamodel::UCloudEventAttributesBuilder;
-    use crate::uprotocol::uattributes::UPriority;
-    use crate::uprotocol::uri::{UAuthority, UEntity};
+    use crate::uprotocol::{UAuthority, UEntity, UPriority};
     use crate::uuid::builder::UUIDv8Builder;
 
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,9 @@ pub mod cloudevent {
     }
 }
 
+// protoc-generated stubs, see build.rs
+include!(concat!(env!("OUT_DIR"), "/cloudevents/mod.rs"));
+
 pub mod rpc {
     mod calloptions;
     mod rpcclient;
@@ -133,65 +136,27 @@ pub mod uuid {
 
 pub mod uprotocol {
     // protoc-generated stubs, see build.rs
-    include!(concat!(env!("OUT_DIR"), "/uprotocol.v1.rs"));
+    include!(concat!(env!("OUT_DIR"), "/uprotocol/mod.rs"));
 
-    pub use crate::proto::uprotocol::uauthority;
-    pub use crate::proto::uprotocol::uentity;
-    pub use crate::proto::uprotocol::umessagetype;
-    pub use crate::proto::uprotocol::upayload;
-    pub use crate::proto::uprotocol::uresource;
-    pub use crate::proto::uprotocol::ustatus;
-    pub use crate::proto::uprotocol::uuid;
-    pub use crate::proto::uprotocol::uuri;
-
-    pub use u_authority::Remote;
-    pub use u_payload::Data;
-
-    // This is to make the more specialized uprotocol types available within the SDK scope;
-    // not required by the code, so not sure whether it'll stay in.
-    mod v1 {
-        // this re-export is necessary to accomodate the package/reference structure of the uprotocol uproto files (included below)
-        pub(crate) use crate::uprotocol::{UCode, UMessage, UStatus, UUri, UUriBatch};
-    }
-    pub mod core {
-        pub mod udiscovery {
-            pub mod v3 {
-                include!(concat!(env!("OUT_DIR"), "/uprotocol.core.udiscovery.v3.rs"));
-            }
-        }
-        pub mod usubscription {
-            pub mod v3 {
-                include!(concat!(
-                    env!("OUT_DIR"),
-                    "/uprotocol.core.usubscription.v3.rs"
-                ));
-            }
-        }
-        pub mod utwin {
-            pub mod v1 {
-                include!(concat!(env!("OUT_DIR"), "/uprotocol.core.utwin.v1.rs"));
-            }
-        }
-    }
+    pub use crate::proto::uprotocol::upayload::*;
+    pub use crate::proto::uprotocol::uuid::*;
 }
 
 #[allow(non_snake_case)]
-pub mod proto {
-    // protoc-generated stubs, see build.rs
-    include!(concat!(env!("OUT_DIR"), "/io.cloudevents.v1.rs"));
+pub(crate) mod proto {
 
-    pub mod cloudevents {
-        pub mod protocloudevent;
+    pub(crate) mod cloudevents {
+        pub(crate) mod protocloudevent;
     }
 
-    pub mod uprotocol {
-        pub mod uauthority;
-        pub mod uentity;
-        pub mod umessagetype;
-        pub mod upayload;
-        pub mod uresource;
-        pub mod ustatus;
-        pub mod uuid;
-        pub mod uuri;
+    pub(crate) mod uprotocol {
+        pub(crate) mod uauthority;
+        pub(crate) mod uentity;
+        pub(crate) mod umessagetype;
+        pub(crate) mod upayload;
+        pub(crate) mod uresource;
+        pub(crate) mod ustatus;
+        pub(crate) mod uuid;
+        pub(crate) mod uuri;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,8 +138,14 @@ pub mod uprotocol {
     // protoc-generated stubs, see build.rs
     include!(concat!(env!("OUT_DIR"), "/uprotocol/mod.rs"));
 
+    pub use self::uuid::UUID;
     pub use crate::proto::uprotocol::upayload::*;
     pub use crate::proto::uprotocol::uuid::*;
+    pub use uattributes::{UAttributes, UMessageType, UPriority};
+    pub use umessage::UMessage;
+    pub use upayload::{upayload::Data, UPayload, UPayloadFormat};
+    pub use uri::{UAuthority, UEntity, UResource, UUri};
+    pub use ustatus::{UCode, UStatus};
 }
 
 #[allow(non_snake_case)]

--- a/src/proto/uprotocol/uauthority.rs
+++ b/src/proto/uprotocol/uauthority.rs
@@ -11,58 +11,27 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use crate::uprotocol::{Remote, UAuthority};
+use crate::uprotocol::uri::UAuthority;
 
 /// Helper functions to deal with `UAuthority::Remote` structure
 impl UAuthority {
-    pub fn has_name(&self) -> bool {
-        matches!(self.remote, Some(Remote::Name(_)))
-    }
-
-    pub fn has_ip(&self) -> bool {
-        matches!(self.remote, Some(Remote::Ip(_)))
-    }
-
-    pub fn has_id(&self) -> bool {
-        matches!(self.remote, Some(Remote::Id(_)))
-    }
-
     pub fn get_name(&self) -> Option<&str> {
-        match &self.remote {
-            Some(Remote::Name(name)) => Some(name),
-            _ => None,
-        }
+        self.name.as_deref()
     }
 
     pub fn get_ip(&self) -> Option<&[u8]> {
-        match &self.remote {
-            Some(Remote::Ip(ip)) => Some(ip),
-            _ => None,
-        }
+        self.ip.as_deref()
+    }
+
+    pub fn has_ip(&self) -> bool {
+        self.ip.is_some()
     }
 
     pub fn get_id(&self) -> Option<&[u8]> {
-        match &self.remote {
-            Some(Remote::Id(id)) => Some(id),
-            _ => None,
-        }
+        self.id.as_deref()
     }
 
-    pub fn set_name<T>(&mut self, name: T) -> &mut Self
-    where
-        T: Into<String>,
-    {
-        self.remote = Some(Remote::Name(name.into()));
-        self
-    }
-
-    pub fn set_ip(&mut self, ip: Vec<u8>) -> &mut Self {
-        self.remote = Some(Remote::Ip(ip));
-        self
-    }
-
-    pub fn set_id(&mut self, id: Vec<u8>) -> &mut Self {
-        self.remote = Some(Remote::Id(id));
-        self
+    pub fn has_id(&self) -> bool {
+        self.id.is_some()
     }
 }

--- a/src/proto/uprotocol/uentity.rs
+++ b/src/proto/uprotocol/uentity.rs
@@ -11,10 +11,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use crate::uprotocol::UEntity;
+use crate::uprotocol::uri::UEntity;
 
 impl UEntity {
-    pub fn has_id(entity: &UEntity) -> bool {
-        entity.id.is_some()
+    pub fn has_id(&self) -> bool {
+        self.id.is_some()
     }
 }

--- a/src/proto/uprotocol/umessagetype.rs
+++ b/src/proto/uprotocol/umessagetype.rs
@@ -13,7 +13,7 @@
 
 use std::fmt::Display;
 
-use crate::uprotocol::UMessageType;
+use crate::uprotocol::uattributes::UMessageType;
 
 impl From<UMessageType> for String {
     fn from(value: UMessageType) -> Self {
@@ -24,10 +24,10 @@ impl From<UMessageType> for String {
 impl From<&str> for UMessageType {
     fn from(value: &str) -> Self {
         match value {
-            "pub.v1" => UMessageType::UmessageTypePublish,
-            "req.v1" => UMessageType::UmessageTypeRequest,
-            "res.v1" => UMessageType::UmessageTypeResponse,
-            _ => UMessageType::UmessageTypeUnspecified,
+            "pub.v1" => UMessageType::UMESSAGE_TYPE_PUBLISH,
+            "req.v1" => UMessageType::UMESSAGE_TYPE_REQUEST,
+            "res.v1" => UMessageType::UMESSAGE_TYPE_RESPONSE,
+            _ => UMessageType::UMESSAGE_TYPE_UNSPECIFIED,
         }
     }
 }
@@ -35,10 +35,10 @@ impl From<&str> for UMessageType {
 impl Display for UMessageType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            UMessageType::UmessageTypePublish => write!(f, "pub.v1"),
-            UMessageType::UmessageTypeRequest => write!(f, "req.v1"),
-            UMessageType::UmessageTypeResponse => write!(f, "res.v1"),
-            UMessageType::UmessageTypeUnspecified => write!(f, "unspec.v1"),
+            UMessageType::UMESSAGE_TYPE_PUBLISH => write!(f, "pub.v1"),
+            UMessageType::UMESSAGE_TYPE_REQUEST => write!(f, "req.v1"),
+            UMessageType::UMESSAGE_TYPE_RESPONSE => write!(f, "res.v1"),
+            UMessageType::UMESSAGE_TYPE_UNSPECIFIED => write!(f, "unspec.v1"),
         }
     }
 }

--- a/src/proto/uprotocol/upayload.rs
+++ b/src/proto/uprotocol/upayload.rs
@@ -11,13 +11,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use prost::Message;
-use prost_types::Any;
+use protobuf::{well_known_types::any::Any, Message};
 
-use crate::{
-    cloudevent::serializer::SerializationError,
-    uprotocol::{Data, UPayload, UPayloadFormat},
-};
+pub use crate::types::serializationerror::SerializationError;
+
+use crate::uprotocol::upayload::{upayload::Data, UPayload, UPayloadFormat};
 
 impl TryFrom<Any> for UPayload {
     type Error = SerializationError;
@@ -30,10 +28,12 @@ impl TryFrom<&Any> for UPayload {
     type Error = SerializationError;
 
     fn try_from(value: &Any) -> Result<Self, Self::Error> {
-        let vec = value.encode_to_vec();
-        i32::try_from(vec.len())
+        let buf = value
+            .write_to_bytes()
+            .map_err(|_e| SerializationError::new("Failed to serialize Any value"))?;
+        i32::try_from(buf.len())
             .map(|len| UPayload {
-                data: Some(Data::Value(vec)),
+                data: Some(Data::Value(buf)),
                 length: Some(len),
                 ..Default::default()
             })
@@ -45,11 +45,12 @@ impl TryFrom<UPayload> for Any {
     type Error = SerializationError;
 
     fn try_from(value: UPayload) -> Result<Self, Self::Error> {
-        match value.format() {
-            UPayloadFormat::UpayloadFormatProtobuf | UPayloadFormat::UpayloadFormatUnspecified => {
+        match value.format.enum_value_or_default() {
+            UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY
+            | UPayloadFormat::UPAYLOAD_FORMAT_UNSPECIFIED => {
                 if let Some(bytes) = data_to_slice(&value) {
                     if !bytes.is_empty() {
-                        return Any::decode(bytes).map_err(|e| {
+                        return Any::parse_from_bytes(bytes).map_err(|e| {
                             SerializationError::new(format!("UPayload does not contain Any: {}", e))
                         });
                     }
@@ -91,8 +92,10 @@ unsafe fn read_memory(_address: u64, _length: i32) -> &'static [u8] {
 
 #[cfg(test)]
 mod tests {
-    use crate::uprotocol::UPayloadFormat;
-    use prost_types::{Any, Timestamp};
+    use crate::uprotocol::upayload::UPayloadFormat;
+    use protobuf::well_known_types::any::Any;
+    use protobuf::well_known_types::timestamp::Timestamp;
+    use protobuf::EnumOrUnknown;
     use test_case::test_case;
 
     use super::*;
@@ -106,26 +109,31 @@ mod tests {
     #[test_case(6, false; "text fails")]
     fn test_into_any_with_payload_format(format: i32, should_succeed: bool) {
         let timestamp = Timestamp::default();
-        let data = Any::from_msg(&timestamp).unwrap().encode_to_vec();
+        let data = Any::pack(&timestamp).unwrap().write_to_bytes().unwrap();
         let payload = UPayload {
-            format,
+            format: EnumOrUnknown::from_i32(format),
             data: Some(Data::Value(data)),
             length: None,
+            ..Default::default()
         };
 
         let any = Any::try_from(payload);
         assert_eq!(any.is_ok(), should_succeed);
         if should_succeed {
-            assert_eq!(any.unwrap().to_msg::<Timestamp>().unwrap(), timestamp);
+            assert_eq!(
+                any.unwrap().unpack::<Timestamp>().unwrap().unwrap(),
+                timestamp
+            );
         }
     }
 
     #[test]
     fn test_into_any_fails_for_empty_data() {
         let payload = UPayload {
-            format: UPayloadFormat::UpayloadFormatProtobuf as i32,
+            format: UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF.into(),
             data: Some(Data::Value(vec![])),
             length: None,
+            ..Default::default()
         };
 
         let any = Any::try_from(payload);
@@ -135,13 +143,16 @@ mod tests {
     #[test]
     fn test_from_any() {
         let timestamp = Timestamp::default();
-        let any = Any::from_msg(&timestamp).unwrap();
+        let any = Any::pack(&timestamp).unwrap();
 
         let payload = UPayload::try_from(&any).unwrap();
         assert_eq!(
             payload.format,
-            UPayloadFormat::UpayloadFormatUnspecified as i32
+            UPayloadFormat::UPAYLOAD_FORMAT_UNSPECIFIED.into()
         );
-        assert_eq!(payload.data.unwrap(), Data::Value(any.encode_to_vec()));
+        assert_eq!(
+            payload.data.unwrap(),
+            Data::Value(any.write_to_bytes().unwrap())
+        );
     }
 }

--- a/src/proto/uprotocol/uresource.rs
+++ b/src/proto/uprotocol/uresource.rs
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use crate::uprotocol::UResource;
+use crate::uprotocol::uri::UResource;
 
 impl UResource {
     pub fn has_id(&self) -> bool {
@@ -47,6 +47,7 @@ impl From<&str> for UResource {
             id: None,
             instance: resource_instance,
             message: resource_message,
+            ..Default::default()
         }
     }
 }

--- a/src/proto/uprotocol/ustatus.rs
+++ b/src/proto/uprotocol/ustatus.rs
@@ -11,26 +11,19 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use prost::Name;
-
-use crate::uprotocol::{UCode, UStatus};
-
-impl Name for UStatus {
-    const NAME: &'static str = "UStatus";
-    const PACKAGE: &'static str = "uprotocol.v1";
-}
+use crate::uprotocol::ustatus::{UCode, UStatus};
 
 impl UStatus {
     pub fn ok() -> Self {
         UStatus {
-            code: UCode::Ok.into(),
+            code: UCode::OK.into(),
             ..Default::default()
         }
     }
 
     pub fn fail(msg: &str) -> Self {
         UStatus {
-            code: UCode::Unknown.into(),
+            code: UCode::UNKNOWN.into(),
             message: Some(msg.to_string()),
             ..Default::default()
         }
@@ -45,18 +38,14 @@ impl UStatus {
     }
 
     pub fn is_failed(&self) -> bool {
-        self.code != UCode::Ok as i32
+        self.get_code() != UCode::OK
     }
 
     pub fn is_success(&self) -> bool {
-        self.code == UCode::Ok as i32
+        self.get_code() == UCode::OK
     }
 
     pub fn get_code(&self) -> UCode {
-        if let Ok(code) = UCode::try_from(self.code) {
-            code
-        } else {
-            UCode::Unknown
-        }
+        self.code.enum_value_or_default()
     }
 }

--- a/src/proto/uprotocol/uuid.rs
+++ b/src/proto/uprotocol/uuid.rs
@@ -14,7 +14,7 @@
 use std::str::FromStr;
 use uuid::{Uuid, Variant, Version};
 
-use crate::uprotocol::Uuid as uproto_Uuid;
+use crate::uprotocol::uuid::UUID as uproto_Uuid;
 
 #[derive(Debug)]
 pub struct UuidConversionError {
@@ -38,6 +38,14 @@ impl std::fmt::Display for UuidConversionError {
 impl std::error::Error for UuidConversionError {}
 
 impl uproto_Uuid {
+    pub fn from_u64_pair(high: u64, low: u64) -> Self {
+        uproto_Uuid {
+            msb: high,
+            lsb: low,
+            ..Default::default()
+        }
+    }
+
     /// Returns a string representation of this UUID as defined by
     /// [RFC 4122, Section 3](https://www.rfc-editor.org/rfc/rfc4122.html#section-3).
     pub fn to_hyphenated_string(&self) -> String {
@@ -107,10 +115,7 @@ impl From<Uuid> for uproto_Uuid {
 impl From<&Uuid> for uproto_Uuid {
     fn from(value: &Uuid) -> Self {
         let pair = value.as_u64_pair();
-        uproto_Uuid {
-            msb: pair.0,
-            lsb: pair.1,
-        }
+        uproto_Uuid::from_u64_pair(pair.0, pair.1)
     }
 }
 
@@ -192,10 +197,10 @@ mod tests {
         let hi = 0xa1a2a3a4b1b2c1c2u64;
         let lo = 0xd1d2d3d4d5d6d7d8u64;
 
-        let uuid = Uuid::from(uproto_Uuid { msb: hi, lsb: lo });
+        let uuid = Uuid::from(uproto_Uuid::from_u64_pair(hi, lo));
         assert_eq!(uuid.as_u64_pair(), (hi, lo));
 
-        let uuid = Uuid::from(&uproto_Uuid { msb: hi, lsb: lo });
+        let uuid = Uuid::from(&uproto_Uuid::from_u64_pair(hi, lo));
         assert_eq!(uuid.as_u64_pair(), (hi, lo));
     }
 
@@ -205,10 +210,10 @@ mod tests {
         let lo = 0xd1d2d3d4d5d6d7d8u64;
         let hyphenated_string = "a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8".to_string();
 
-        let uuid_string = String::from(uproto_Uuid { msb: hi, lsb: lo });
+        let uuid_string = String::from(uproto_Uuid::from_u64_pair(hi, lo));
         assert_eq!(uuid_string, hyphenated_string);
 
-        let uuid_string = String::from(&uproto_Uuid { msb: hi, lsb: lo });
+        let uuid_string = String::from(&uproto_Uuid::from_u64_pair(hi, lo));
         assert_eq!(uuid_string, hyphenated_string);
     }
 
@@ -247,7 +252,7 @@ mod tests {
         ];
         let hi = 0xa1a2a3a4b1b2c1c2u64;
         let lo = 0xd1d2d3d4d5d6d7d8u64;
-        let uuid = uproto_Uuid { msb: hi, lsb: lo };
+        let uuid = uproto_Uuid::from_u64_pair(hi, lo);
 
         let uuid_as_bytes: [u8; 16] = (&uuid).into();
         assert_eq!(uuid_as_bytes, bytes);
@@ -259,30 +264,30 @@ mod tests {
     #[test]
     fn test_is_uprotocol_uuid_succeeds() {
         // timestamp = 1, ver = 0b1000
-        let msb = 0x0000000000018000u64;
+        let hi = 0x0000000000018000u64;
         // variant = 0b10
-        let lsb = 0x8000000000000000u64;
-        let uuid = uproto_Uuid { msb, lsb };
+        let lo = 0x8000000000000000u64;
+        let uuid = uproto_Uuid::from_u64_pair(hi, lo);
         assert!(uuid.is_uprotocol_uuid());
     }
 
     #[test]
     fn test_is_uprotocol_uuid_fails_for_invalid_version() {
         // timestamp = 1, ver = 0b1100
-        let msb = 0x000000000001C000u64;
+        let hi = 0x000000000001C000u64;
         // variant = 0b10
-        let lsb = 0x8000000000000000u64;
-        let uuid = uproto_Uuid { msb, lsb };
+        let lo = 0x8000000000000000u64;
+        let uuid = uproto_Uuid::from_u64_pair(hi, lo);
         assert!(!uuid.is_uprotocol_uuid());
     }
 
     #[test]
     fn test_is_uprotocol_uuid_fails_for_invalid_variant() {
         // timestamp = 1, ver = 0b1000
-        let msb = 0x0000000000018000u64;
+        let hi = 0x0000000000018000u64;
         // variant = 0b01
-        let lsb = 0x4000000000000000u64;
-        let uuid = uproto_Uuid { msb, lsb };
+        let lo = 0x4000000000000000u64;
+        let uuid = uproto_Uuid::from_u64_pair(hi, lo);
         assert!(!uuid.is_uprotocol_uuid());
     }
 }

--- a/src/proto/uprotocol/uuri.rs
+++ b/src/proto/uprotocol/uuri.rs
@@ -11,9 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use std::fmt::Display;
-
-use crate::uprotocol::UUri as uproto_Uuri;
+use crate::uprotocol::uri::UUri as uproto_Uuri;
 use crate::uri::serializer::{LongUriSerializer, MicroUriSerializer, UriSerializer};
 
 impl From<uproto_Uuri> for String {
@@ -53,12 +51,5 @@ impl From<Vec<u8>> for uproto_Uuri {
         } else {
             uproto_Uuri::default()
         }
-    }
-}
-
-impl Display for uproto_Uuri {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let uri = LongUriSerializer::serialize(self).unwrap_or_default();
-        write!(f, "{uri}")
     }
 }

--- a/src/rpc/rpcclient.rs
+++ b/src/rpc/rpcclient.rs
@@ -13,8 +13,10 @@
 
 use async_trait::async_trait;
 
-use crate::rpc::rpcmapper::RpcMapperError;
-use crate::uprotocol::{UAttributes, UPayload, UUri};
+use crate::{
+    rpc::rpcmapper::RpcMapperError,
+    uprotocol::{uattributes::UAttributes, upayload::UPayload, uri::UUri},
+};
 
 pub type RpcClientResult = Result<UPayload, RpcMapperError>;
 

--- a/src/rpc/rpcclient.rs
+++ b/src/rpc/rpcclient.rs
@@ -13,10 +13,8 @@
 
 use async_trait::async_trait;
 
-use crate::{
-    rpc::rpcmapper::RpcMapperError,
-    uprotocol::{uattributes::UAttributes, upayload::UPayload, uri::UUri},
-};
+use crate::rpc::rpcmapper::RpcMapperError;
+use crate::uprotocol::{UAttributes, UPayload, UUri};
 
 pub type RpcClientResult = Result<UPayload, RpcMapperError>;
 

--- a/src/rpc/rpcmapper.rs
+++ b/src/rpc/rpcmapper.rs
@@ -17,9 +17,7 @@ use std::default::Default;
 use std::fmt;
 
 use crate::rpc::rpcclient::RpcClientResult;
-use crate::uprotocol::upayload::upayload::Data;
-use crate::uprotocol::upayload::{UPayload, UPayloadFormat};
-use crate::uprotocol::ustatus::{UCode, UStatus};
+use crate::uprotocol::{Data, UCode, UPayload, UPayloadFormat, UStatus};
 
 pub type RpcPayloadResult = Result<RpcPayload, RpcMapperError>;
 
@@ -300,7 +298,7 @@ mod tests {
     use cloudevents::{Event, EventBuilder, EventBuilderV10};
 
     use crate::cloudevents::CloudEvent as CloudEventProto;
-    use crate::uprotocol::uattributes::UMessageType;
+    use crate::uprotocol::UMessageType;
 
     fn build_status_response(code: UCode, msg: &str) -> RpcClientResult {
         let status = UStatus::fail_with_code(code, msg);

--- a/src/rpc/rpcresult.rs
+++ b/src/rpc/rpcresult.rs
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use crate::uprotocol::ustatus::{UCode, UStatus};
+use crate::uprotocol::{UCode, UStatus};
 
 /// A wrapper for RPC stub calls.
 ///

--- a/src/transport/builder/uattributesbuilder.rs
+++ b/src/transport/builder/uattributesbuilder.rs
@@ -11,12 +11,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use crate::uprotocol::{UAttributes, UMessageType, UPriority, UUri, Uuid};
+use crate::uprotocol::uattributes::{UAttributes, UMessageType, UPriority};
+use crate::uprotocol::uri::UUri;
+use crate::uprotocol::uuid::UUID;
 use crate::uuid::builder::UUIDv8Builder;
 
 /// Builder for easy construction of the `UAttributes` object.
 pub struct UAttributesBuilder {
-    id: Uuid,
+    id: UUID,
     message_type: UMessageType,
     priority: UPriority,
     ttl: Option<i32>,
@@ -24,7 +26,7 @@ pub struct UAttributesBuilder {
     sink: Option<UUri>,
     plevel: Option<i32>,
     commstatus: Option<i32>,
-    reqid: Option<Uuid>,
+    reqid: Option<UUID>,
 }
 
 impl UAttributesBuilder {
@@ -40,7 +42,7 @@ impl UAttributesBuilder {
     pub fn publish(priority: UPriority) -> UAttributesBuilder {
         UAttributesBuilder {
             id: UUIDv8Builder::new().build(),
-            message_type: UMessageType::UmessageTypePublish,
+            message_type: UMessageType::UMESSAGE_TYPE_PUBLISH,
             priority,
             ttl: None,
             token: None,
@@ -64,7 +66,7 @@ impl UAttributesBuilder {
     pub fn notification(priority: UPriority, sink: UUri) -> UAttributesBuilder {
         UAttributesBuilder {
             id: UUIDv8Builder::new().build(),
-            message_type: UMessageType::UmessageTypePublish,
+            message_type: UMessageType::UMESSAGE_TYPE_PUBLISH,
             priority,
             ttl: None,
             token: None,
@@ -89,7 +91,7 @@ impl UAttributesBuilder {
     pub fn request(priority: UPriority, sink: UUri, ttl: u32) -> UAttributesBuilder {
         UAttributesBuilder {
             id: UUIDv8Builder::new().build(),
-            message_type: UMessageType::UmessageTypeRequest,
+            message_type: UMessageType::UMESSAGE_TYPE_REQUEST,
             priority,
             ttl: Some(i32::try_from(ttl).unwrap_or(i32::MAX)),
             token: None,
@@ -111,10 +113,10 @@ impl UAttributesBuilder {
     /// # Returns
     ///
     /// The builder initialized with the given values.
-    pub fn response(priority: UPriority, sink: UUri, reqid: Uuid) -> UAttributesBuilder {
+    pub fn response(priority: UPriority, sink: UUri, reqid: UUID) -> UAttributesBuilder {
         UAttributesBuilder {
             id: UUIDv8Builder::new().build(),
-            message_type: UMessageType::UmessageTypeResponse,
+            message_type: UMessageType::UMESSAGE_TYPE_RESPONSE,
             priority,
             ttl: None,
             token: None,
@@ -213,7 +215,7 @@ impl UAttributesBuilder {
     ///
     /// The builder.
     #[must_use]
-    pub fn with_reqid(&mut self, reqid: Uuid) -> &mut UAttributesBuilder {
+    pub fn with_reqid(&mut self, reqid: UUID) -> &mut UAttributesBuilder {
         self.reqid = Some(reqid);
         self
     }
@@ -225,15 +227,16 @@ impl UAttributesBuilder {
     /// The attributes.
     pub fn build(&self) -> UAttributes {
         UAttributes {
-            id: Some(self.id.clone()),
-            r#type: self.message_type.into(),
+            id: Some(self.id.clone()).into(),
+            type_: self.message_type.into(),
             priority: self.priority.into(),
             ttl: self.ttl,
             token: self.token.clone(),
-            sink: self.sink.clone(),
+            sink: self.sink.clone().into(),
             permission_level: self.plevel,
             commstatus: self.commstatus,
-            reqid: self.reqid.clone(),
+            reqid: self.reqid.clone().into(),
+            ..Default::default()
         }
     }
 }

--- a/src/transport/builder/uattributesbuilder.rs
+++ b/src/transport/builder/uattributesbuilder.rs
@@ -11,9 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use crate::uprotocol::uattributes::{UAttributes, UMessageType, UPriority};
-use crate::uprotocol::uri::UUri;
-use crate::uprotocol::uuid::UUID;
+use crate::uprotocol::{UAttributes, UMessageType, UPriority, UUri, UUID};
 use crate::uuid::builder::UUIDv8Builder;
 
 /// Builder for easy construction of the `UAttributes` object.

--- a/src/transport/datamodel/utransport.rs
+++ b/src/transport/datamodel/utransport.rs
@@ -13,10 +13,7 @@
 
 use async_trait::async_trait;
 
-use crate::uprotocol::{
-    uattributes::UAttributes, umessage::UMessage, upayload::UPayload, uri::UEntity, uri::UUri,
-    ustatus::UStatus,
-};
+use crate::uprotocol::{UAttributes, UEntity, UMessage, UPayload, UStatus, UUri};
 
 /// `UTransport` is the uP-L1 interface that provides a common API for uE developers to send and receive messages.
 ///

--- a/src/transport/datamodel/utransport.rs
+++ b/src/transport/datamodel/utransport.rs
@@ -13,7 +13,10 @@
 
 use async_trait::async_trait;
 
-use crate::uprotocol::{UAttributes, UEntity, UMessage, UPayload, UStatus, UUri};
+use crate::uprotocol::{
+    uattributes::UAttributes, umessage::UMessage, upayload::UPayload, uri::UEntity, uri::UUri,
+    ustatus::UStatus,
+};
 
 /// `UTransport` is the uP-L1 interface that provides a common API for uE developers to send and receive messages.
 ///

--- a/src/transport/validator/uattributesvalidator.rs
+++ b/src/transport/validator/uattributesvalidator.rs
@@ -16,9 +16,7 @@ use std::time::SystemTime;
 use protobuf::Enum;
 
 use crate::transport::validator::ValidationError;
-use crate::uprotocol::{
-    uattributes::UAttributes, uattributes::UMessageType, ustatus::UCode, uuid::UUID,
-};
+use crate::uprotocol::{UAttributes, UCode, UMessageType, UUID};
 use crate::uri::validator::UriValidator;
 
 /// `UAttributes` is the struct that defines the Payload. It serves as the configuration for various aspects
@@ -497,9 +495,7 @@ impl UAttributesValidator for ResponseValidator {
 mod tests {
     use super::*;
     use crate::transport::builder::UAttributesBuilder;
-    use crate::uprotocol::{
-        uattributes::UPriority, uri::UAuthority, uri::UEntity, uri::UUri, uuid::UUID,
-    };
+    use crate::uprotocol::{UAuthority, UEntity, UPriority, UUri, UUID};
     use crate::uri::builder::resourcebuilder::UResourceBuilder;
     use crate::uuid::builder::UUIDv8Builder;
 

--- a/src/transport/validator/uattributesvalidator.rs
+++ b/src/transport/validator/uattributesvalidator.rs
@@ -13,8 +13,12 @@
 
 use std::time::SystemTime;
 
+use protobuf::Enum;
+
 use crate::transport::validator::ValidationError;
-use crate::uprotocol::{UAttributes, UCode, UMessageType, Uuid};
+use crate::uprotocol::{
+    uattributes::UAttributes, uattributes::UMessageType, ustatus::UCode, uuid::UUID,
+};
 use crate::uri::validator::UriValidator;
 
 /// `UAttributes` is the struct that defines the Payload. It serves as the configuration for various aspects
@@ -100,7 +104,7 @@ pub trait UAttributesValidator {
             None => 0,
         };
 
-        if let Some(time) = attributes.id.as_ref().and_then(Uuid::get_time) {
+        if let Some(time) = attributes.id.as_ref().and_then(UUID::get_time) {
             let delta = match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
                 Ok(duration) => {
                     if let Ok(duration) = u64::try_from(duration.as_millis()) {
@@ -173,7 +177,7 @@ pub trait UAttributesValidator {
     ///
     /// The function does not return an error if the `UAttributes` object does not contain a `sink`, considering it a valid case.
     fn validate_sink(&self, attributes: &UAttributes) -> Result<(), ValidationError> {
-        if let Some(sink) = &attributes.sink {
+        if let Some(sink) = attributes.sink.as_ref() {
             return UriValidator::validate(sink);
         }
         Ok(())
@@ -227,7 +231,7 @@ pub trait UAttributesValidator {
     /// The function does not return an error if the `UAttributes` object does not contain a `reqid`, considering it a valid case.
     fn validate_commstatus(&self, attributes: &UAttributes) -> Result<(), ValidationError> {
         if let Some(cs) = attributes.commstatus {
-            if UCode::try_from(cs).is_err() {
+            if UCode::from_i32(cs).is_none() {
                 return Err(ValidationError::new(format!(
                     "Invalid Communication Status Code [{cs}]"
                 )));
@@ -255,7 +259,7 @@ pub trait UAttributesValidator {
     ///
     /// The function considers the absence of a request ID in `UAttributes` as a valid case and does not return an error in such a scenario.
     fn validate_reqid(&self, attributes: &UAttributes) -> Result<(), ValidationError> {
-        if let Some(reqid) = &attributes.reqid {
+        if let Some(reqid) = &attributes.reqid.as_ref() {
             if !reqid.is_uprotocol_uuid() {
                 return Err(ValidationError::new("Invalid UUID"));
             }
@@ -299,12 +303,12 @@ impl Validators {
     }
 
     pub fn get_validator(attributes: &UAttributes) -> Box<dyn UAttributesValidator> {
-        if let Ok(mt) = UMessageType::try_from(attributes.r#type) {
+        if let Ok(mt) = attributes.type_.enum_value() {
             match mt {
-                UMessageType::UmessageTypePublish => return Box::new(PublishValidator),
-                UMessageType::UmessageTypeRequest => return Box::new(RequestValidator),
-                UMessageType::UmessageTypeResponse => return Box::new(ResponseValidator),
-                UMessageType::UmessageTypeUnspecified => {}
+                UMessageType::UMESSAGE_TYPE_PUBLISH => return Box::new(PublishValidator),
+                UMessageType::UMESSAGE_TYPE_REQUEST => return Box::new(RequestValidator),
+                UMessageType::UMESSAGE_TYPE_RESPONSE => return Box::new(ResponseValidator),
+                UMessageType::UMESSAGE_TYPE_UNSPECIFIED => {}
             }
         }
         Box::new(PublishValidator)
@@ -329,21 +333,19 @@ impl UAttributesValidator for PublishValidator {
     ///
     /// Returns a `ValidationResult` that is success or failed with a failure message.
     fn validate_type(&self, attributes: &UAttributes) -> Result<(), ValidationError> {
-        if let Ok(mt) = UMessageType::try_from(attributes.r#type) {
-            match mt {
-                UMessageType::UmessageTypePublish => return Ok(()),
-                _ => {
-                    return Err(ValidationError::new(format!(
-                        "Wrong Attribute Type [{}]",
-                        mt.as_str_name()
-                    )));
-                }
-            }
+        match attributes.type_.enum_value() {
+            Err(unknown_code) => Err(ValidationError::new(format!(
+                "Unknown Attribute Type [{}]",
+                unknown_code
+            ))),
+            Ok(mt) => match mt {
+                UMessageType::UMESSAGE_TYPE_PUBLISH => Ok(()),
+                _ => Err(ValidationError::new(format!(
+                    "Wrong Attribute Type [{}]",
+                    mt
+                ))),
+            },
         }
-        Err(ValidationError::new(format!(
-            "Unknown Attribute Type [{}]",
-            attributes.r#type
-        )))
     }
 }
 
@@ -365,21 +367,19 @@ impl UAttributesValidator for RequestValidator {
     ///
     /// Returns a `ValidationResult` that is success or failed with a failure message.
     fn validate_type(&self, attributes: &UAttributes) -> Result<(), ValidationError> {
-        if let Ok(mt) = UMessageType::try_from(attributes.r#type) {
-            match mt {
-                UMessageType::UmessageTypeRequest => return Ok(()),
-                _ => {
-                    return Err(ValidationError::new(format!(
-                        "Wrong Attribute Type [{}]",
-                        mt.as_str_name()
-                    )));
-                }
-            }
+        match attributes.type_.enum_value() {
+            Err(unknown_code) => Err(ValidationError::new(format!(
+                "Unknown Attribute Type [{}]",
+                unknown_code
+            ))),
+            Ok(mt) => match mt {
+                UMessageType::UMESSAGE_TYPE_REQUEST => Ok(()),
+                _ => Err(ValidationError::new(format!(
+                    "Wrong Attribute Type [{}]",
+                    mt
+                ))),
+            },
         }
-        Err(ValidationError::new(format!(
-            "Unknown Attribute Type [{}]",
-            attributes.r#type
-        )))
     }
 
     /// Validates that attributes for a message meant for an RPC request has a destination sink.
@@ -393,7 +393,7 @@ impl UAttributesValidator for RequestValidator {
     ///
     /// Returns a `ValidationResult` that is success or failed with a failure message.
     fn validate_sink(&self, attributes: &UAttributes) -> Result<(), ValidationError> {
-        if let Some(sink) = &attributes.sink {
+        if let Some(sink) = &attributes.sink.as_ref() {
             UriValidator::validate_rpc_method(sink)
         } else {
             Err(ValidationError::new("Missing Sink"))
@@ -441,21 +441,19 @@ impl UAttributesValidator for ResponseValidator {
     ///
     /// Returns a `ValidationResult` that is success or failed with a failure message.
     fn validate_type(&self, attributes: &UAttributes) -> Result<(), ValidationError> {
-        if let Ok(mt) = UMessageType::try_from(attributes.r#type) {
-            match mt {
-                UMessageType::UmessageTypeResponse => return Ok(()),
-                _ => {
-                    return Err(ValidationError::new(format!(
-                        "Wrong Attribute Type [{}]",
-                        mt.as_str_name()
-                    )));
-                }
-            }
+        match attributes.type_.enum_value() {
+            Err(unknown_code) => Err(ValidationError::new(format!(
+                "Unknown Attribute Type [{}]",
+                unknown_code
+            ))),
+            Ok(mt) => match mt {
+                UMessageType::UMESSAGE_TYPE_RESPONSE => Ok(()),
+                _ => Err(ValidationError::new(format!(
+                    "Wrong Attribute Type [{}]",
+                    mt
+                ))),
+            },
         }
-        Err(ValidationError::new(format!(
-            "Unknown Attribute Type [{}]",
-            attributes.r#type
-        )))
     }
 
     /// Validates that attributes for a message meant for an RPC response has a destination sink.
@@ -469,7 +467,7 @@ impl UAttributesValidator for ResponseValidator {
     ///
     /// Returns a `ValidationResult` that is success or failed with a failure message.
     fn validate_sink(&self, attributes: &UAttributes) -> Result<(), ValidationError> {
-        if let Some(sink) = &attributes.sink {
+        if let Some(sink) = &attributes.sink.as_ref() {
             UriValidator::validate_rpc_response(sink)
         } else {
             Err(ValidationError::new("Missing Sink"))
@@ -486,15 +484,12 @@ impl UAttributesValidator for ResponseValidator {
     ///
     /// Returns a `ValidationResult` that is success or failed with a failure message.
     fn validate_reqid(&self, attributes: &UAttributes) -> Result<(), ValidationError> {
-        if let Some(reqid) = &attributes.reqid {
-            if *reqid == Uuid::default() {
-                return Err(ValidationError::new("Missing correlation Id"));
-            }
+        if let Some(reqid) = &attributes.reqid.as_ref() {
             if reqid.is_uprotocol_uuid() {
                 return Ok(());
             }
         }
-        Err(ValidationError::new("Missing correlation Id"))
+        Err(ValidationError::new("Missing correlation ID"))
     }
 }
 
@@ -502,14 +497,16 @@ impl UAttributesValidator for ResponseValidator {
 mod tests {
     use super::*;
     use crate::transport::builder::UAttributesBuilder;
-    use crate::uprotocol::{Remote, UAuthority, UEntity, UPriority, UUri, Uuid};
+    use crate::uprotocol::{
+        uattributes::UPriority, uri::UAuthority, uri::UEntity, uri::UUri, uuid::UUID,
+    };
     use crate::uri::builder::resourcebuilder::UResourceBuilder;
     use crate::uuid::builder::UUIDv8Builder;
 
     #[test]
     fn test_fetching_validator_for_valid_types() {
         // Test for PUBLISH type
-        let publish_attributes = UAttributesBuilder::publish(UPriority::UpriorityCs0).build();
+        let publish_attributes = UAttributesBuilder::publish(UPriority::UPRIORITY_CS0).build();
         let publish_validator: Box<dyn UAttributesValidator> =
             Validators::get_validator(&publish_attributes);
         assert_eq!(
@@ -519,7 +516,7 @@ mod tests {
 
         // Test for REQUEST type
         let request_attributes =
-            UAttributesBuilder::request(UPriority::UpriorityCs4, build_sink(), 1000).build();
+            UAttributesBuilder::request(UPriority::UPRIORITY_CS4, build_sink(), 1000).build();
         let request_validator = Validators::get_validator(&request_attributes);
         assert_eq!(
             request_validator.type_name(),
@@ -527,9 +524,12 @@ mod tests {
         );
 
         // Test for RESPONSE type
-        let response_attributes =
-            UAttributesBuilder::response(UPriority::UpriorityCs4, UUri::default(), Uuid::default())
-                .build();
+        let response_attributes = UAttributesBuilder::response(
+            UPriority::UPRIORITY_CS4,
+            UUri::default(),
+            UUID::default(),
+        )
+        .build();
         let response_validator = Validators::get_validator(&response_attributes);
         assert_eq!(
             response_validator.type_name(),
@@ -539,7 +539,7 @@ mod tests {
 
     #[test]
     fn test_validate_attributes_for_publish_message_payload() {
-        let attributes = UAttributesBuilder::publish(UPriority::UpriorityCs0).build();
+        let attributes = UAttributesBuilder::publish(UPriority::UPRIORITY_CS0).build();
         let validator = Validators::Publish.validator();
         let status = validator.validate(&attributes);
         assert!(status.is_ok());
@@ -547,7 +547,7 @@ mod tests {
 
     #[test]
     fn test_validate_attributes_for_publish_message_payload_all_values() {
-        let attributes = UAttributesBuilder::publish(UPriority::UpriorityCs0)
+        let attributes = UAttributesBuilder::publish(UPriority::UPRIORITY_CS0)
             .with_ttl(1000)
             .with_sink(build_sink())
             .with_permission_level(2)
@@ -562,7 +562,7 @@ mod tests {
     #[test]
     fn test_validate_attributes_for_publish_message_payload_invalid_type() {
         let attributes = UAttributesBuilder::response(
-            UPriority::UpriorityCs0,
+            UPriority::UPRIORITY_CS0,
             build_sink(),
             UUIDv8Builder::new().build(),
         )
@@ -571,15 +571,11 @@ mod tests {
         let validator = Validators::Publish.validator();
         let status = validator.validate(&attributes);
         assert!(status.is_err());
-        assert_eq!(
-            status.unwrap_err().to_string(),
-            "Wrong Attribute Type [UMESSAGE_TYPE_RESPONSE]"
-        );
     }
 
     #[test]
     fn test_validate_attributes_for_publish_message_payload_invalid_ttl() {
-        let attributes = UAttributesBuilder::publish(UPriority::UpriorityCs0)
+        let attributes = UAttributesBuilder::publish(UPriority::UPRIORITY_CS0)
             .with_ttl(0)
             .build();
 
@@ -591,7 +587,7 @@ mod tests {
 
     #[test]
     fn test_validate_attributes_for_publish_message_payload_invalid_sink() {
-        let attributes = UAttributesBuilder::publish(UPriority::UpriorityCs0)
+        let attributes = UAttributesBuilder::publish(UPriority::UPRIORITY_CS0)
             .with_sink(UUri::default())
             .build();
 
@@ -603,7 +599,7 @@ mod tests {
 
     #[test]
     fn test_validate_attributes_for_publish_message_payload_invalid_permission_level() {
-        let attributes = UAttributesBuilder::publish(UPriority::UpriorityCs0)
+        let attributes = UAttributesBuilder::publish(UPriority::UPRIORITY_CS0)
             .with_permission_level(0)
             .build();
 
@@ -617,7 +613,7 @@ mod tests {
 
     #[test]
     fn test_validate_attributes_for_publish_message_payload_communication_status() {
-        let attributes = UAttributesBuilder::publish(UPriority::UpriorityCs0)
+        let attributes = UAttributesBuilder::publish(UPriority::UPRIORITY_CS0)
             .with_commstatus(-42)
             .build();
 
@@ -632,8 +628,8 @@ mod tests {
 
     #[test]
     fn test_validate_attributes_for_publish_message_payload_request_id() {
-        let attributes = UAttributesBuilder::publish(UPriority::UpriorityCs0)
-            .with_reqid(Uuid::from(uuid::Uuid::new_v4()))
+        let attributes = UAttributesBuilder::publish(UPriority::UPRIORITY_CS0)
+            .with_reqid(UUID::from(uuid::Uuid::new_v4()))
             .build();
 
         let validator = Validators::Publish.validator();
@@ -645,7 +641,7 @@ mod tests {
     #[test]
     fn test_validate_attributes_for_rpc_request_message_payload() {
         let attributes =
-            UAttributesBuilder::request(UPriority::UpriorityCs4, build_sink(), 1000).build();
+            UAttributesBuilder::request(UPriority::UPRIORITY_CS4, build_sink(), 1000).build();
 
         let validator = Validators::Request.validator();
         let status = validator.validate(&attributes);
@@ -654,7 +650,7 @@ mod tests {
 
     #[test]
     fn test_validate_attributes_for_rpc_request_message_payload_all_values() {
-        let attributes = UAttributesBuilder::request(UPriority::UpriorityCs4, build_sink(), 1000)
+        let attributes = UAttributesBuilder::request(UPriority::UPRIORITY_CS4, build_sink(), 1000)
             .with_permission_level(2)
             .with_commstatus(3)
             .with_reqid(UUIDv8Builder::new().build())
@@ -668,7 +664,7 @@ mod tests {
     #[test]
     fn test_validate_attributes_for_rpc_request_message_payload_invalid_type() {
         let attributes = UAttributesBuilder::response(
-            UPriority::UpriorityCs4,
+            UPriority::UPRIORITY_CS4,
             build_sink(),
             UUIDv8Builder::new().build(),
         )
@@ -678,65 +674,54 @@ mod tests {
         let validator = Validators::Request.validator();
         let status = validator.validate(&attributes);
         assert!(status.is_err());
-        assert_eq!(
-            status.unwrap_err().to_string(),
-            "Wrong Attribute Type [UMESSAGE_TYPE_RESPONSE]"
-        );
     }
 
     #[test]
     fn test_validate_attributes_for_rpc_request_message_payload_invalid_ttl() {
         let attributes =
-            UAttributesBuilder::request(UPriority::UpriorityCs4, build_sink(), 0).build();
+            UAttributesBuilder::request(UPriority::UPRIORITY_CS4, build_sink(), 0).build();
 
         let validator = Validators::Request.validator();
         let status = validator.validate(&attributes);
         assert!(status.is_err());
-        assert_eq!(status.unwrap_err().to_string(), "Invalid TTL [0]");
     }
 
     #[test]
     fn test_validate_attributes_for_rpc_request_message_payload_invalid_sink() {
         let attributes =
-            UAttributesBuilder::request(UPriority::UpriorityCs4, UUri::default(), 1000).build();
+            UAttributesBuilder::request(UPriority::UPRIORITY_CS4, UUri::default(), 1000).build();
 
         let validator = Validators::Request.validator();
         let status = validator.validate(&attributes);
         assert!(status.is_err());
-        assert_eq!(status.unwrap_err().to_string(), "Uri is empty");
     }
 
     #[test]
     fn test_validate_attributes_for_rpc_request_message_payload_invalid_permission_level() {
-        let attributes = UAttributesBuilder::request(UPriority::UpriorityCs4, build_sink(), 1000)
+        let attributes = UAttributesBuilder::request(UPriority::UPRIORITY_CS4, build_sink(), 1000)
             .with_permission_level(0)
             .build();
 
         let validator = Validators::Request.validator();
         let status = validator.validate(&attributes);
         assert!(status.is_err());
-        assert_eq!(status.unwrap_err().to_string(), "Invalid Permission Level");
     }
 
     #[test]
     fn test_validate_attributes_for_rpc_request_message_payload_invalid_communication_status() {
-        let attributes = UAttributesBuilder::request(UPriority::UpriorityCs4, build_sink(), 1000)
+        let attributes = UAttributesBuilder::request(UPriority::UPRIORITY_CS4, build_sink(), 1000)
             .with_commstatus(-42)
             .build();
 
         let validator = Validators::Request.validator();
         let status = validator.validate(&attributes);
         assert!(status.is_err());
-        assert_eq!(
-            status.unwrap_err().to_string(),
-            "Invalid Communication Status Code [-42]"
-        );
     }
 
     #[test]
     fn test_validate_attributes_for_rpc_request_message_payload_invalid_request_id() {
-        let attributes = UAttributesBuilder::request(UPriority::UpriorityCs4, build_sink(), 1000)
-            .with_reqid(Uuid::from(uuid::Uuid::new_v4()))
+        let attributes = UAttributesBuilder::request(UPriority::UPRIORITY_CS4, build_sink(), 1000)
+            .with_reqid(UUID::from(uuid::Uuid::new_v4()))
             .build();
 
         let validator = Validators::Request.validator();
@@ -748,7 +733,7 @@ mod tests {
     #[test]
     fn test_validate_attributes_for_rpc_response_message_payload() {
         let attributes = UAttributesBuilder::response(
-            UPriority::UpriorityCs4,
+            UPriority::UPRIORITY_CS4,
             build_sink(),
             UUIDv8Builder::new().build(),
         )
@@ -762,7 +747,7 @@ mod tests {
     #[test]
     fn test_validate_attributes_for_rpc_response_message_payload_all_values() {
         let attributes = UAttributesBuilder::response(
-            UPriority::UpriorityCs4,
+            UPriority::UPRIORITY_CS4,
             build_sink(),
             UUIDv8Builder::new().build(),
         )
@@ -778,27 +763,17 @@ mod tests {
     #[test]
     fn test_validate_attributes_for_rpc_response_message_payload_invalid_type() {
         let attributes =
-            UAttributesBuilder::notification(UPriority::UpriorityCs4, build_sink()).build();
+            UAttributesBuilder::notification(UPriority::UPRIORITY_CS4, build_sink()).build();
 
         let validator = Validators::Response.validator();
         let status = validator.validate(&attributes);
         assert!(status.is_err());
-        assert!(status
-            .as_ref()
-            .unwrap_err()
-            .to_string()
-            .contains("Wrong Attribute Type [UMESSAGE_TYPE_PUBLISH]"));
-        assert!(status
-            .as_ref()
-            .unwrap_err()
-            .to_string()
-            .contains("Missing correlation Id"));
     }
 
     #[test]
     fn test_validate_attributes_for_rpc_response_message_payload_invalid_ttl() {
         let attributes = UAttributesBuilder::response(
-            UPriority::UpriorityCs4,
+            UPriority::UPRIORITY_CS4,
             build_sink(),
             UUIDv8Builder::new().build(),
         )
@@ -814,7 +789,7 @@ mod tests {
     #[test]
     fn test_validate_attributes_for_rpc_response_message_payload_invalid_permission_level() {
         let attributes = UAttributesBuilder::response(
-            UPriority::UpriorityCs4,
+            UPriority::UPRIORITY_CS4,
             build_sink(),
             UUIDv8Builder::new().build(),
         )
@@ -830,7 +805,7 @@ mod tests {
     #[test]
     fn test_validate_attributes_for_rpc_response_message_payload_invalid_communication_status() {
         let attributes = UAttributesBuilder::response(
-            UPriority::UpriorityCs4,
+            UPriority::UPRIORITY_CS4,
             build_sink(),
             UUIDv8Builder::new().build(),
         )
@@ -849,34 +824,32 @@ mod tests {
     #[test]
     fn test_validate_attributes_for_rpc_response_message_payload_missing_request_id() {
         let attributes_builder =
-            UAttributesBuilder::response(UPriority::UpriorityCs4, build_sink(), Uuid::default());
+            UAttributesBuilder::response(UPriority::UPRIORITY_CS4, build_sink(), UUID::default());
         let attributes = attributes_builder.build();
 
         let validator = Validators::Response.validator();
         let status = validator.validate(&attributes);
         assert!(status.is_err());
-        assert_eq!(status.unwrap_err().to_string(), "Missing correlation Id");
     }
 
     #[test]
     fn test_validate_attributes_for_rpc_response_message_payload_invalid_request_id() {
         let attributes = UAttributesBuilder::response(
-            UPriority::UpriorityCs4,
+            UPriority::UPRIORITY_CS4,
             build_sink(),
             UUIDv8Builder::new().build(),
         )
-        .with_reqid(Uuid::from(uuid::Uuid::new_v4()))
+        .with_reqid(UUID::from(uuid::Uuid::new_v4()))
         .build();
 
         let validator = Validators::Response.validator();
         let status = validator.validate(&attributes);
         assert!(status.is_err());
-        assert_eq!(status.unwrap_err().to_string(), "Missing correlation Id");
     }
 
     #[test]
     fn test_validate_attributes_for_publish_message_payload_not_expired() {
-        let attributes = UAttributesBuilder::publish(UPriority::UpriorityCs0).build();
+        let attributes = UAttributesBuilder::publish(UPriority::UPRIORITY_CS0).build();
 
         let validator = Validators::Publish.validator();
         let status: Result<(), ValidationError> = validator.is_expired(&attributes);
@@ -885,7 +858,7 @@ mod tests {
 
     #[test]
     fn test_validate_attributes_for_publish_message_payload_not_expired_with_ttl_zero() {
-        let attributes = UAttributesBuilder::publish(UPriority::UpriorityCs0)
+        let attributes = UAttributesBuilder::publish(UPriority::UPRIORITY_CS0)
             .with_ttl(0)
             .build();
 
@@ -896,7 +869,7 @@ mod tests {
 
     #[test]
     fn test_validate_attributes_for_publish_message_payload_not_expired_with_ttl() {
-        let attributes = UAttributesBuilder::publish(UPriority::UpriorityCs0)
+        let attributes = UAttributesBuilder::publish(UPriority::UPRIORITY_CS0)
             .with_ttl(10000)
             .build();
 
@@ -907,7 +880,7 @@ mod tests {
 
     #[test]
     fn test_validate_attributes_for_publish_message_payload_expired() {
-        let attributes = UAttributesBuilder::publish(UPriority::UpriorityCs0)
+        let attributes = UAttributesBuilder::publish(UPriority::UPRIORITY_CS0)
             .with_ttl(1)
             .build();
 
@@ -921,7 +894,7 @@ mod tests {
 
     #[test]
     fn test_validating_request_containing_token() {
-        let attributes = UAttributesBuilder::publish(UPriority::UpriorityCs0)
+        let attributes = UAttributesBuilder::publish(UPriority::UPRIORITY_CS0)
             .with_token("None")
             .build();
 
@@ -934,16 +907,18 @@ mod tests {
     fn build_sink() -> UUri {
         UUri {
             authority: Some(UAuthority {
-                remote: Some(Remote::Name(
-                    "vcu.someVin.veh.uprotocol.corp.com".to_string(),
-                )),
-            }),
+                name: Some(String::from("vcu.someVin.veh.uprotocol.corp.com")),
+                ..Default::default()
+            })
+            .into(),
             entity: Some(UEntity {
                 name: "petapp.uprotocol.corp.com".to_string(),
                 version_major: Some(1),
                 ..Default::default()
-            }),
-            resource: Some(UResourceBuilder::for_rpc_response()),
+            })
+            .into(),
+            resource: Some(UResourceBuilder::for_rpc_response()).into(),
+            ..Default::default()
         }
     }
 }

--- a/src/uri/builder/resourcebuilder.rs
+++ b/src/uri/builder/resourcebuilder.rs
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use crate::uprotocol::uri::UResource;
+use crate::uprotocol::UResource;
 
 const MAX_RPC_ID: u32 = 1000;
 

--- a/src/uri/builder/resourcebuilder.rs
+++ b/src/uri/builder/resourcebuilder.rs
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use crate::uprotocol::UResource;
+use crate::uprotocol::uri::UResource;
 
 const MAX_RPC_ID: u32 = 1000;
 
@@ -28,6 +28,7 @@ impl UResourceBuilder {
             instance: Some(String::from("response")),
             id: Some(0),
             message: None,
+            ..Default::default()
         }
     }
 
@@ -45,6 +46,7 @@ impl UResourceBuilder {
             instance: method,
             id,
             message: None,
+            ..Default::default()
         }
     }
 
@@ -70,6 +72,7 @@ impl UResourceBuilder {
             instance: None,
             id: Some(id),
             message: None,
+            ..Default::default()
         }
     }
 }

--- a/src/uri/serializer/longuriserializer.rs
+++ b/src/uri/serializer/longuriserializer.rs
@@ -15,7 +15,7 @@
 
 use regex::Regex;
 
-use crate::uprotocol::uri::{UAuthority, UEntity, UResource, UUri};
+use crate::uprotocol::{UAuthority, UEntity, UResource, UUri};
 use crate::uri::serializer::{SerializationError, UriSerializer};
 use crate::uri::validator::UriValidator;
 

--- a/src/uri/serializer/longuriserializer.rs
+++ b/src/uri/serializer/longuriserializer.rs
@@ -11,9 +11,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+// use regex::Regex;
+
 use regex::Regex;
 
-use crate::uprotocol::{Remote, UAuthority, UEntity, UResource, UUri};
+use crate::uprotocol::uri::{UAuthority, UEntity, UResource, UUri};
 use crate::uri::serializer::{SerializationError, UriSerializer};
 use crate::uri::validator::UriValidator;
 
@@ -28,15 +30,16 @@ impl UriSerializer<String> for LongUriSerializer {
         }
 
         let mut output = String::default();
-        if let Some(authority) = &uri.authority {
+        if let Some(authority) = uri.authority.as_ref() {
             output.push_str(&Self::build_authority_part_of_uri(authority));
         }
         output.push('/');
-        if let Some(entity) = &uri.entity {
+        if let Some(entity) = uri.entity.as_ref() {
             output.push_str(&Self::build_entity_part_of_uri(entity));
         }
         output.push_str(&Self::build_resource_part_of_uri(uri));
 
+        // remove trailing slashes
         Ok(Regex::new(r"/+$")
             .unwrap()
             .replace_all(&output, "")
@@ -90,7 +93,8 @@ impl UriSerializer<String> for LongUriSerializer {
                     return Err(SerializationError::new("URI is invalid"));
                 }
                 authority = Some(UAuthority {
-                    remote: Some(Remote::Name(uri_parts[2].to_string())),
+                    name: Some(uri_parts[2].clone()),
+                    ..Default::default()
                 });
             }
             if uri_parts.len() > 3 {
@@ -103,7 +107,7 @@ impl UriSerializer<String> for LongUriSerializer {
                 }
             } else {
                 return Ok(UUri {
-                    authority,
+                    authority: authority.into(),
                     ..Default::default()
                 });
             }
@@ -128,9 +132,10 @@ impl UriSerializer<String> for LongUriSerializer {
         };
 
         Ok(UUri {
-            entity: Some(entity),
-            authority,
-            resource,
+            entity: Some(entity).into(),
+            authority: authority.into(),
+            resource: resource.into(),
+            ..Default::default()
         })
     }
 }
@@ -148,7 +153,7 @@ impl LongUriSerializer {
     fn build_resource_part_of_uri(uri: &UUri) -> String {
         let mut output = String::default();
 
-        if let Some(resource) = &uri.resource {
+        if let Some(resource) = uri.resource.as_ref() {
             output.push('/');
             output.push_str(&resource.name);
 
@@ -194,8 +199,8 @@ impl LongUriSerializer {
     /// Returns the `String` representation of the `Authority` in the uProtocol URI.
     fn build_authority_part_of_uri(authority: &UAuthority) -> String {
         let mut output = String::from("//");
-        if let Some(crate::uprotocol::u_authority::Remote::Name(name)) = &authority.remote {
-            output.push_str(name);
+        if let Some(name) = authority.name.as_ref() {
+            output.push_str(name.as_str());
         }
         output
     }
@@ -203,9 +208,13 @@ impl LongUriSerializer {
     // This function is meant to replicate the behavior of the Java
     // `String[] java.lang.String.split(String regex)` method.
     fn java_split(input: &str, pattern: &str) -> Vec<String> {
-        let re = Regex::new(pattern).unwrap();
-        let mut result: Vec<String> = re
-            .split(input)
+        // let re = Regex::new(pattern).unwrap();
+        // let mut result: Vec<String> = re
+        //     .split(input)
+        //     .map(std::string::ToString::to_string)
+        //     .collect();
+        let mut result: Vec<String> = input
+            .split(pattern)
             .map(std::string::ToString::to_string)
             .collect();
 
@@ -235,9 +244,10 @@ mod tests {
         };
         let resource = UResourceBuilder::for_rpc_request(Some("raise".into()), None);
         let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: None,
+            entity: Some(entity).into(),
+            resource: Some(resource).into(),
+            authority: None.into(),
+            ..Default::default()
         };
         let uristr = LongUriSerializer::serialize(&uri);
         assert_eq!("/hartley//rpc.raise", uristr.as_ref().unwrap());
@@ -458,26 +468,15 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_protocol_uri_with_remote_service_only_device_and_domain() {
+    fn test_parse_protocol_uri_with_remote_service_only_device_and_cloud_domain() {
         let uri_result = LongUriSerializer::deserialize("//VCU.MY_CAR_VIN".to_string());
         assert!(uri_result.is_ok());
         let uri = uri_result.unwrap();
         assert!(UriValidator::is_remote(&uri));
-        if let Some(Remote::Name(name)) = uri.authority.as_ref().and_then(|a| a.remote.as_ref()) {
-            assert_eq!("VCU.MY_CAR_VIN", name);
-        }
-    }
-
-    #[test]
-    fn test_parse_protocol_uri_with_remote_service_only_device_and_cloud_domain() {
-        let uri_result =
-            LongUriSerializer::deserialize("//cloud.uprotocol.example.com".to_string());
-        assert!(uri_result.is_ok());
-        let uri = uri_result.unwrap();
-        assert!(UriValidator::is_remote(&uri));
-        if let Some(Remote::Name(name)) = uri.authority.as_ref().and_then(|a| a.remote.as_ref()) {
-            assert_eq!("cloud.uprotocol.example.com", name);
-        }
+        assert_eq!(
+            Some("VCU.MY_CAR_VIN"),
+            uri.authority.get_or_default().get_name()
+        );
         assert!(uri.entity.is_none());
         assert!(uri.resource.is_none());
     }
@@ -488,26 +487,13 @@ mod tests {
         assert!(uri_result.is_ok());
         let uri = uri_result.unwrap();
         assert!(UriValidator::is_remote(&uri));
-        if let Some(Remote::Name(name)) = uri.authority.as_ref().and_then(|a| a.remote.as_ref()) {
-            assert_eq!("VCU.MY_CAR_VIN", name);
-        }
+        assert_eq!(
+            Some("VCU.MY_CAR_VIN"),
+            uri.authority.get_or_default().get_name()
+        );
         assert!(uri.entity.is_some());
-        assert_eq!("body.access", uri.entity.as_ref().unwrap().name);
-        assert!(uri.resource.is_none());
-    }
-
-    #[test]
-    fn test_parse_protocol_uri_with_remote_cloud_service_no_version() {
-        let uri_result =
-            LongUriSerializer::deserialize("//cloud.uprotocol.example.com/body.access".to_string());
-        assert!(uri_result.is_ok());
-        let uri = uri_result.unwrap();
-        assert!(UriValidator::is_remote(&uri));
-        if let Some(Remote::Name(name)) = uri.authority.as_ref().and_then(|a| a.remote.as_ref()) {
-            assert_eq!("cloud.uprotocol.example.com", name);
-        }
-        assert!(uri.entity.is_some());
-        assert_eq!("body.access", uri.entity.as_ref().unwrap().name);
+        assert_eq!("body.access", uri.entity.get_or_default().name);
+        assert!(uri.entity.get_or_default().version_major.is_none());
         assert!(uri.resource.is_none());
     }
 
@@ -518,29 +504,13 @@ mod tests {
         assert!(uri_result.is_ok());
         let uri = uri_result.unwrap();
         assert!(UriValidator::is_remote(&uri));
-        if let Some(Remote::Name(name)) = uri.authority.as_ref().and_then(|a| a.remote.as_ref()) {
-            assert_eq!("VCU.MY_CAR_VIN", name);
-        }
-        assert!(uri.entity.is_some());
-        assert_eq!("body.access", uri.entity.as_ref().unwrap().name);
-        assert_eq!(1, uri.entity.as_ref().unwrap().version_major.unwrap());
-        assert!(uri.resource.is_none());
-    }
-
-    #[test]
-    fn test_parse_protocol_uri_with_remote_cloud_service_with_version() {
-        let uri_result = LongUriSerializer::deserialize(
-            "//cloud.uprotocol.example.com/body.access/1".to_string(),
+        assert_eq!(
+            Some("VCU.MY_CAR_VIN"),
+            uri.authority.get_or_default().get_name()
         );
-        assert!(uri_result.is_ok());
-        let uri = uri_result.unwrap();
-        assert!(UriValidator::is_remote(&uri));
-        if let Some(Remote::Name(name)) = uri.authority.as_ref().and_then(|a| a.remote.as_ref()) {
-            assert_eq!("cloud.uprotocol.example.com", name);
-        }
         assert!(uri.entity.is_some());
-        assert_eq!("body.access", uri.entity.as_ref().unwrap().name);
-        assert_eq!(1, uri.entity.as_ref().unwrap().version_major.unwrap());
+        assert_eq!("body.access", uri.entity.get_or_default().name);
+        assert_eq!(Some(1), uri.entity.get_or_default().version_major);
         assert!(uri.resource.is_none());
     }
 
@@ -551,34 +521,17 @@ mod tests {
         assert!(uri_result.is_ok());
         let uri = uri_result.unwrap();
         assert!(UriValidator::is_remote(&uri));
-        if let Some(Remote::Name(name)) = uri.authority.as_ref().and_then(|a| a.remote.as_ref()) {
-            assert_eq!("VCU.MY_CAR_VIN", name);
-        }
-        assert!(uri.entity.is_some());
-        assert_eq!("body.access", uri.entity.as_ref().unwrap().name);
-        assert!(uri.resource.is_some());
-        assert_eq!("door", uri.resource.as_ref().unwrap().name);
-        assert!(uri.resource.as_ref().unwrap().instance.is_none());
-        assert!(uri.resource.as_ref().unwrap().message.is_none());
-    }
-
-    #[test]
-    fn test_parse_protocol_uri_with_remote_cloud_service_no_version_with_resource_name_only() {
-        let uri_result = LongUriSerializer::deserialize(
-            "//cloud.uprotocol.example.com/body.access//door".to_string(),
+        assert_eq!(
+            Some("VCU.MY_CAR_VIN"),
+            uri.authority.get_or_default().get_name()
         );
-        assert!(uri_result.is_ok());
-        let uri = uri_result.unwrap();
-        assert!(UriValidator::is_remote(&uri));
-        if let Some(Remote::Name(name)) = uri.authority.as_ref().and_then(|a| a.remote.as_ref()) {
-            assert_eq!("cloud.uprotocol.example.com", name);
-        }
         assert!(uri.entity.is_some());
-        assert_eq!("body.access", uri.entity.as_ref().unwrap().name);
+        assert_eq!("body.access", uri.entity.get_or_default().name);
+        assert!(uri.entity.get_or_default().version_major.is_none());
         assert!(uri.resource.is_some());
-        assert_eq!("door", uri.resource.as_ref().unwrap().name);
-        assert!(uri.resource.as_ref().unwrap().instance.is_none());
-        assert!(uri.resource.as_ref().unwrap().message.is_none());
+        assert_eq!("door", uri.resource.get_or_default().name);
+        assert!(uri.resource.get_instance().is_none());
+        assert!(uri.resource.get_message().is_none());
     }
 
     #[test]
@@ -590,19 +543,18 @@ mod tests {
         assert!(uri_result.is_ok());
         let uri = uri_result.unwrap();
         assert!(UriValidator::is_remote(&uri));
-        if let Some(Remote::Name(name)) = uri.authority.as_ref().and_then(|a| a.remote.as_ref()) {
-            assert_eq!("VCU.MY_CAR_VIN", name);
-        }
-        assert!(uri.entity.is_some());
-        assert_eq!("body.access", uri.entity.as_ref().unwrap().name);
-        assert!(uri.resource.is_some());
-        assert_eq!("door", uri.resource.as_ref().unwrap().name);
-        assert!(uri.resource.as_ref().unwrap().instance.is_some());
         assert_eq!(
-            "front_left",
-            uri.resource.as_ref().unwrap().instance.as_ref().unwrap()
+            Some("VCU.MY_CAR_VIN"),
+            uri.authority.get_or_default().get_name()
         );
-        assert!(uri.resource.as_ref().unwrap().message.is_none());
+        assert!(uri.entity.is_some());
+        assert_eq!("body.access", uri.entity.get_or_default().name);
+        assert!(uri.entity.get_or_default().version_major.is_none());
+        assert!(uri.resource.is_some());
+        assert_eq!("door", uri.resource.get_or_default().name);
+        assert!(uri.resource.as_ref().unwrap().instance.is_some());
+        assert_eq!(Some("front_left"), uri.resource.get_instance());
+        assert!(uri.resource.get_message().is_none());
     }
 
     #[test]
@@ -614,20 +566,18 @@ mod tests {
         assert!(uri_result.is_ok());
         let uri = uri_result.unwrap();
         assert!(UriValidator::is_remote(&uri));
-        if let Some(Remote::Name(name)) = uri.authority.as_ref().and_then(|a| a.remote.as_ref()) {
-            assert_eq!("VCU.MY_CAR_VIN", name);
-        }
-        assert!(uri.entity.is_some());
-        assert_eq!("body.access", uri.entity.as_ref().unwrap().name);
-        assert_eq!(1, uri.entity.as_ref().unwrap().version_major.unwrap());
-        assert!(uri.resource.is_some());
-        assert_eq!("door", uri.resource.as_ref().unwrap().name);
-        assert!(uri.resource.as_ref().unwrap().instance.is_some());
         assert_eq!(
-            "front_left",
-            uri.resource.as_ref().unwrap().instance.as_ref().unwrap()
+            Some("VCU.MY_CAR_VIN"),
+            uri.authority.get_or_default().get_name()
         );
-        assert!(uri.resource.as_ref().unwrap().message.is_none());
+        assert!(uri.entity.is_some());
+        assert_eq!("body.access", uri.entity.get_or_default().name);
+        assert_eq!(Some(1), uri.entity.get_or_default().version_major);
+        assert!(uri.resource.is_some());
+        assert_eq!("door", uri.resource.get_or_default().name);
+        assert!(uri.resource.as_ref().unwrap().instance.is_some());
+        assert_eq!(Some("front_left"), uri.resource.get_instance());
+        assert!(uri.resource.get_message().is_none());
     }
 
     #[test]
@@ -639,51 +589,18 @@ mod tests {
         assert!(uri_result.is_ok());
         let uri = uri_result.unwrap();
         assert!(UriValidator::is_remote(&uri));
-        if let Some(Remote::Name(name)) = uri.authority.as_ref().and_then(|a| a.remote.as_ref()) {
-            assert_eq!("VCU.MY_CAR_VIN", name);
-        }
+        assert_eq!(
+            Some("VCU.MY_CAR_VIN"),
+            uri.authority.get_or_default().get_name()
+        );
         assert!(uri.entity.is_some());
-        assert_eq!("body.access", uri.entity.as_ref().unwrap().name);
+        assert_eq!("body.access", uri.entity.get_or_default().name);
+        assert!(uri.entity.get_or_default().version_major.is_none());
         assert!(uri.resource.is_some());
-        assert_eq!("door", uri.resource.as_ref().unwrap().name);
+        assert_eq!("door", uri.resource.get_or_default().name);
         assert!(uri.resource.as_ref().unwrap().instance.is_some());
-        assert_eq!(
-            "front_left",
-            uri.resource.as_ref().unwrap().instance.as_ref().unwrap()
-        );
-        assert!(uri.resource.as_ref().unwrap().message.is_some());
-        assert_eq!(
-            "Door",
-            uri.resource.as_ref().unwrap().message.as_ref().unwrap()
-        );
-    }
-
-    #[test]
-    fn test_parse_protocol_uri_with_remote_cloud_service_no_version_with_resource_and_instance_and_message(
-    ) {
-        let uri_result = LongUriSerializer::deserialize(
-            "//cloud.uprotocol.example.com/body.access//door.front_left#Door".to_string(),
-        );
-        assert!(uri_result.is_ok());
-        let uri = uri_result.unwrap();
-        assert!(UriValidator::is_remote(&uri));
-        if let Some(Remote::Name(name)) = uri.authority.as_ref().and_then(|a| a.remote.as_ref()) {
-            assert_eq!("cloud.uprotocol.example.com", name);
-        }
-        assert!(uri.entity.is_some());
-        assert_eq!("body.access", uri.entity.as_ref().unwrap().name);
-        assert!(uri.resource.is_some());
-        assert_eq!("door", uri.resource.as_ref().unwrap().name);
-        assert!(uri.resource.as_ref().unwrap().instance.is_some());
-        assert_eq!(
-            "front_left",
-            uri.resource.as_ref().unwrap().instance.as_ref().unwrap()
-        );
-        assert!(uri.resource.as_ref().unwrap().message.is_some());
-        assert_eq!(
-            "Door",
-            uri.resource.as_ref().unwrap().message.as_ref().unwrap()
-        );
+        assert_eq!(Some("front_left"), uri.resource.get_instance());
+        assert_eq!(Some("Door"), uri.resource.get_message());
     }
 
     #[test]
@@ -695,77 +612,18 @@ mod tests {
         assert!(uri_result.is_ok());
         let uri = uri_result.unwrap();
         assert!(UriValidator::is_remote(&uri));
-        if let Some(Remote::Name(name)) = uri.authority.as_ref().and_then(|a| a.remote.as_ref()) {
-            assert_eq!("VCU.MY_CAR_VIN", name);
-        }
+        assert_eq!(
+            Some("VCU.MY_CAR_VIN"),
+            uri.authority.get_or_default().get_name()
+        );
         assert!(uri.entity.is_some());
-        assert_eq!("body.access", uri.entity.as_ref().unwrap().name);
-        assert_eq!(1, uri.entity.as_ref().unwrap().version_major.unwrap());
+        assert_eq!("body.access", uri.entity.get_or_default().name);
+        assert_eq!(Some(1), uri.entity.get_or_default().version_major);
         assert!(uri.resource.is_some());
-        assert_eq!("door", uri.resource.as_ref().unwrap().name);
+        assert_eq!("door", uri.resource.get_or_default().name);
         assert!(uri.resource.as_ref().unwrap().instance.is_some());
-        assert_eq!(
-            "front_left",
-            uri.resource.as_ref().unwrap().instance.as_ref().unwrap()
-        );
-        assert!(uri.resource.as_ref().unwrap().message.is_some());
-        assert_eq!(
-            "Door",
-            uri.resource.as_ref().unwrap().message.as_ref().unwrap()
-        );
-    }
-
-    #[test]
-    fn test_parse_protocol_uri_with_remote_cloud_service_with_version_with_resource_and_instance_and_message(
-    ) {
-        let uri_result = LongUriSerializer::deserialize(
-            "//cloud.uprotocol.example.com/body.access/1/door.front_left#Door".to_string(),
-        );
-        assert!(uri_result.is_ok());
-        let uri = uri_result.unwrap();
-        assert!(UriValidator::is_remote(&uri));
-        if let Some(Remote::Name(name)) = uri.authority.as_ref().and_then(|a| a.remote.as_ref()) {
-            assert_eq!("cloud.uprotocol.example.com", name);
-        }
-        assert!(uri.entity.is_some());
-        assert_eq!("body.access", uri.entity.as_ref().unwrap().name);
-        assert_eq!(1, uri.entity.as_ref().unwrap().version_major.unwrap());
-        assert!(uri.resource.is_some());
-        assert_eq!("door", uri.resource.as_ref().unwrap().name);
-        assert!(uri.resource.as_ref().unwrap().instance.is_some());
-        assert_eq!(
-            "front_left",
-            uri.resource.as_ref().unwrap().instance.as_ref().unwrap()
-        );
-        assert!(uri.resource.as_ref().unwrap().message.is_some());
-        assert_eq!(
-            "Door",
-            uri.resource.as_ref().unwrap().message.as_ref().unwrap()
-        );
-    }
-
-    #[test]
-    fn test_parse_protocol_uri_with_remote_service_no_domain_with_version_with_resource_and_instance_no_message(
-    ) {
-        let uri_result =
-            LongUriSerializer::deserialize("//VCU/body.access/1/door.front_left".to_string());
-        assert!(uri_result.is_ok());
-        let uri = uri_result.unwrap();
-        assert!(UriValidator::is_remote(&uri));
-        if let Some(Remote::Name(name)) = uri.authority.as_ref().and_then(|a| a.remote.as_ref()) {
-            assert_eq!("VCU", name);
-        }
-        assert!(uri.entity.is_some());
-        assert_eq!("body.access", uri.entity.as_ref().unwrap().name);
-        assert_eq!(1, uri.entity.as_ref().unwrap().version_major.unwrap());
-        assert!(uri.resource.is_some());
-        assert_eq!("door", uri.resource.as_ref().unwrap().name);
-        assert!(uri.resource.as_ref().unwrap().instance.is_some());
-        assert_eq!(
-            "front_left",
-            uri.resource.as_ref().unwrap().instance.as_ref().unwrap()
-        );
-        assert!(uri.resource.as_ref().unwrap().message.is_none());
+        assert_eq!(Some("front_left"), uri.resource.get_instance());
+        assert_eq!(Some("Door"), uri.resource.get_message());
     }
 
     #[test]
@@ -775,19 +633,14 @@ mod tests {
         assert!(uri_result.is_ok());
         let uri = uri_result.unwrap();
         assert!(UriValidator::is_remote(&uri));
-        if let Some(Remote::Name(name)) = uri.authority.as_ref().and_then(|a| a.remote.as_ref()) {
-            assert_eq!("bo.cloud", name);
-        }
+        assert_eq!(Some("bo.cloud"), uri.authority.get_or_default().get_name());
         assert!(uri.entity.is_some());
-        assert_eq!("petapp", uri.entity.as_ref().unwrap().name);
+        assert_eq!("petapp", uri.entity.get_or_default().name);
+        assert!(uri.entity.get_or_default().version_major.is_none());
         assert!(uri.resource.is_some());
-        assert_eq!("rpc", uri.resource.as_ref().unwrap().name);
-        assert!(uri.resource.as_ref().unwrap().instance.is_some());
-        assert_eq!(
-            "response",
-            uri.resource.as_ref().unwrap().instance.as_ref().unwrap()
-        );
-        assert!(uri.resource.as_ref().unwrap().message.is_none());
+        assert_eq!("rpc", uri.resource.get_or_default().name);
+        assert_eq!(Some("response"), uri.resource.get_instance());
+        assert!(uri.resource.get_message().is_none());
     }
 
     #[test]
@@ -797,20 +650,14 @@ mod tests {
         assert!(uri_result.is_ok());
         let uri = uri_result.unwrap();
         assert!(UriValidator::is_remote(&uri));
-        if let Some(Remote::Name(name)) = uri.authority.as_ref().and_then(|a| a.remote.as_ref()) {
-            assert_eq!("bo.cloud", name);
-        }
+        assert_eq!(Some("bo.cloud"), uri.authority.get_or_default().get_name());
         assert!(uri.entity.is_some());
-        assert_eq!("petapp", uri.entity.as_ref().unwrap().name);
-        assert_eq!(1, uri.entity.as_ref().unwrap().version_major.unwrap());
+        assert_eq!("petapp", uri.entity.get_or_default().name);
+        assert_eq!(Some(1), uri.entity.get_or_default().version_major);
         assert!(uri.resource.is_some());
-        assert_eq!("rpc", uri.resource.as_ref().unwrap().name);
-        assert!(uri.resource.as_ref().unwrap().instance.is_some());
-        assert_eq!(
-            "response",
-            uri.resource.as_ref().unwrap().instance.as_ref().unwrap()
-        );
-        assert!(uri.resource.as_ref().unwrap().message.is_none());
+        assert_eq!("rpc", uri.resource.get_or_default().name);
+        assert_eq!(Some("response"), uri.resource.get_instance());
+        assert!(uri.resource.get_message().is_none());
     }
 
     #[test]
@@ -828,9 +675,10 @@ mod tests {
             ..Default::default()
         };
         let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: Some(UAuthority::default()),
+            entity: Some(entity).into(),
+            resource: Some(resource).into(),
+            authority: Some(UAuthority::default()).into(),
+            ..Default::default()
         };
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_ok());
@@ -844,9 +692,10 @@ mod tests {
             ..Default::default()
         };
         let uri = UUri {
-            entity: Some(entity),
-            resource: None,
-            authority: None,
+            entity: Some(entity).into(),
+            resource: None.into(),
+            authority: None.into(),
+            ..Default::default()
         };
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_ok());
@@ -862,9 +711,10 @@ mod tests {
         };
         let resource = UResource::default();
         let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: None,
+            entity: Some(entity).into(),
+            resource: Some(resource).into(),
+            authority: None.into(),
+            ..Default::default()
         };
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_ok());
@@ -883,9 +733,10 @@ mod tests {
             ..Default::default()
         };
         let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: None,
+            entity: Some(entity).into(),
+            resource: Some(resource).into(),
+            authority: None.into(),
+            ..Default::default()
         };
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_ok());
@@ -905,9 +756,10 @@ mod tests {
             ..Default::default()
         };
         let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: None,
+            entity: Some(entity).into(),
+            resource: Some(resource).into(),
+            authority: None.into(),
+            ..Default::default()
         };
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_ok());
@@ -927,9 +779,10 @@ mod tests {
             ..Default::default()
         };
         let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: None,
+            entity: Some(entity).into(),
+            resource: Some(resource).into(),
+            authority: None.into(),
+            ..Default::default()
         };
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_ok());
@@ -950,9 +803,10 @@ mod tests {
             ..Default::default()
         };
         let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: None,
+            entity: Some(entity).into(),
+            resource: Some(resource).into(),
+            authority: None.into(),
+            ..Default::default()
         };
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_ok());
@@ -973,9 +827,10 @@ mod tests {
             ..Default::default()
         };
         let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: None,
+            entity: Some(entity).into(),
+            resource: Some(resource).into(),
+            authority: None.into(),
+            ..Default::default()
         };
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_ok());
@@ -1000,9 +855,10 @@ mod tests {
             ..Default::default()
         };
         let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: None,
+            entity: Some(entity).into(),
+            resource: Some(resource).into(),
+            authority: None.into(),
+            ..Default::default()
         };
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_ok());
@@ -1019,12 +875,14 @@ mod tests {
             ..Default::default()
         };
         let authority = UAuthority {
-            remote: Some(Remote::Name("vcu.my_car_vin".into())),
+            name: Some(String::from("vcu.my_car_vin")),
+            ..Default::default()
         };
         let uri = UUri {
-            entity: Some(entity),
-            resource: None,
-            authority: Some(authority),
+            entity: Some(entity).into(),
+            resource: None.into(),
+            authority: Some(authority).into(),
+            ..Default::default()
         };
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_ok());
@@ -1039,39 +897,18 @@ mod tests {
             ..Default::default()
         };
         let authority = UAuthority {
-            remote: Some(Remote::Name("vcu.my_car_vin".into())),
+            name: Some(String::from("vcu.my_car_vin")),
+            ..Default::default()
         };
         let uri = UUri {
-            entity: Some(entity),
-            resource: None,
-            authority: Some(authority),
+            entity: Some(entity).into(),
+            resource: None.into(),
+            authority: Some(authority).into(),
+            ..Default::default()
         };
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_ok());
         assert_eq!("//vcu.my_car_vin/body.access/1", uprotocol_uri.unwrap());
-    }
-
-    #[test]
-    fn test_build_protocol_uri_from_uri_when_uri_has_remote_cloud_authority_service_and_version() {
-        let entity = UEntity {
-            name: "body.access".into(),
-            version_major: Some(1),
-            ..Default::default()
-        };
-        let authority = UAuthority {
-            remote: Some(Remote::Name("cloud.uprotocol.example.com".into())),
-        };
-        let uri = UUri {
-            entity: Some(entity),
-            resource: None,
-            authority: Some(authority),
-        };
-        let uprotocol_uri = LongUriSerializer::serialize(&uri);
-        assert!(uprotocol_uri.is_ok());
-        assert_eq!(
-            "//cloud.uprotocol.example.com/body.access/1",
-            uprotocol_uri.unwrap()
-        );
     }
 
     #[test]
@@ -1083,16 +920,18 @@ mod tests {
             ..Default::default()
         };
         let authority = UAuthority {
-            remote: Some(Remote::Name("vcu.my_car_vin".into())),
+            name: Some(String::from("vcu.my_car_vin")),
+            ..Default::default()
         };
         let resource = UResource {
             name: "door".into(),
             ..Default::default()
         };
         let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: Some(authority),
+            entity: Some(entity).into(),
+            resource: Some(resource).into(),
+            authority: Some(authority).into(),
+            ..Default::default()
         };
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_ok());
@@ -1110,16 +949,18 @@ mod tests {
             ..Default::default()
         };
         let authority = UAuthority {
-            remote: Some(Remote::Name("vcu.my_car_vin".into())),
+            name: Some(String::from("vcu.my_car_vin")),
+            ..Default::default()
         };
         let resource = UResource {
             name: "door".into(),
             ..Default::default()
         };
         let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: Some(authority),
+            entity: Some(entity).into(),
+            resource: Some(resource).into(),
+            authority: Some(authority).into(),
+            ..Default::default()
         };
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_ok());
@@ -1135,7 +976,8 @@ mod tests {
             ..Default::default()
         };
         let authority = UAuthority {
-            remote: Some(Remote::Name("vcu.my_car_vin".into())),
+            name: Some(String::from("vcu.my_car_vin")),
+            ..Default::default()
         };
         let resource = UResource {
             name: "door".into(),
@@ -1143,44 +985,15 @@ mod tests {
             ..Default::default()
         };
         let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: Some(authority),
+            entity: Some(entity).into(),
+            resource: Some(resource).into(),
+            authority: Some(authority).into(),
+            ..Default::default()
         };
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_ok());
         assert_eq!(
             "//vcu.my_car_vin/body.access/1/door.front_left",
-            uprotocol_uri.unwrap()
-        );
-    }
-
-    #[test]
-    fn test_build_protocol_uri_from_uri_when_uri_has_remote_cloud_authority_service_and_version_with_resource_with_instance_no_message(
-    ) {
-        let entity = UEntity {
-            name: "body.access".into(),
-            version_major: Some(1),
-            ..Default::default()
-        };
-        let authority = UAuthority {
-            remote: Some(Remote::Name("cloud.uprotocol.example.com".into())),
-        };
-        let resource = UResource {
-            name: "door".into(),
-            instance: Some("front_left".into()),
-            ..Default::default()
-        };
-        let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: Some(authority),
-        };
-
-        let uprotocol_uri = LongUriSerializer::serialize(&uri);
-        assert!(uprotocol_uri.is_ok());
-        assert_eq!(
-            "//cloud.uprotocol.example.com/body.access/1/door.front_left",
             uprotocol_uri.unwrap()
         );
     }
@@ -1193,7 +1006,8 @@ mod tests {
             ..Default::default()
         };
         let authority = UAuthority {
-            remote: Some(Remote::Name("vcu.my_car_vin".into())),
+            name: Some(String::from("vcu.my_car_vin")),
+            ..Default::default()
         };
         let resource = UResource {
             name: "door".into(),
@@ -1201,9 +1015,10 @@ mod tests {
             ..Default::default()
         };
         let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: Some(authority),
+            entity: Some(entity).into(),
+            resource: Some(resource).into(),
+            authority: Some(authority).into(),
+            ..Default::default()
         };
 
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
@@ -1223,7 +1038,8 @@ mod tests {
             ..Default::default()
         };
         let authority = UAuthority {
-            remote: Some(Remote::Name("vcu.my_car_vin".into())),
+            name: Some(String::from("vcu.my_car_vin")),
+            ..Default::default()
         };
         let resource = UResource {
             name: "door".into(),
@@ -1232,9 +1048,10 @@ mod tests {
             ..Default::default()
         };
         let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: Some(authority),
+            entity: Some(entity).into(),
+            resource: Some(resource).into(),
+            authority: Some(authority).into(),
+            ..Default::default()
         };
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_ok());
@@ -1252,7 +1069,8 @@ mod tests {
             ..Default::default()
         };
         let authority = UAuthority {
-            remote: Some(Remote::Name("vcu.my_car_vin".into())),
+            name: Some(String::from("vcu.my_car_vin")),
+            ..Default::default()
         };
         let resource = UResource {
             name: "door".into(),
@@ -1261,9 +1079,10 @@ mod tests {
             ..Default::default()
         };
         let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: Some(authority),
+            entity: Some(entity).into(),
+            resource: Some(resource).into(),
+            authority: Some(authority).into(),
+            ..Default::default()
         };
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_ok());
@@ -1286,40 +1105,14 @@ mod tests {
             ..Default::default()
         };
         let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: None,
+            entity: Some(entity).into(),
+            resource: Some(resource).into(),
+            authority: None.into(),
+            ..Default::default()
         };
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_ok());
         assert_eq!("/petapp/1/rpc.response", uprotocol_uri.unwrap());
-    }
-
-    #[test]
-    fn test_build_protocol_uri_for_source_part_of_rpc_request_where_source_is_remote() {
-        let entity = UEntity {
-            name: "petapp".into(),
-            ..Default::default()
-        };
-        let authority = UAuthority {
-            remote: Some(Remote::Name("cloud.uprotocol.example.com".into())),
-        };
-        let resource = UResource {
-            name: "rpc".into(),
-            instance: Some("response".into()),
-            ..Default::default()
-        };
-        let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: Some(authority),
-        };
-        let uprotocol_uri = LongUriSerializer::serialize(&uri);
-        assert!(uprotocol_uri.is_ok());
-        assert_eq!(
-            "//cloud.uprotocol.example.com/petapp//rpc.response",
-            uprotocol_uri.unwrap()
-        );
     }
 
     #[test]
@@ -1331,16 +1124,18 @@ mod tests {
             ..Default::default()
         };
         let authority = UAuthority {
-            remote: Some(Remote::Name("vcu.my_car_vin".into())),
+            name: Some(String::from("vcu.my_car_vin")),
+            ..Default::default()
         };
         let resource = UResource {
             name: "door".into(),
             ..Default::default()
         };
         let uri = UUri {
-            entity: Some(entity),
-            resource: Some(resource),
-            authority: Some(authority),
+            entity: Some(entity).into(),
+            resource: Some(resource).into(),
+            authority: Some(authority).into(),
+            ..Default::default()
         };
         let uprotocol_uri = LongUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_ok());

--- a/src/uri/serializer/microuriserializer.rs
+++ b/src/uri/serializer/microuriserializer.rs
@@ -11,11 +11,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use byteorder::WriteBytesExt;
-use std::io::Cursor;
+use bytes::{Buf, BufMut};
 use std::io::Write;
 
-use crate::uprotocol::{Remote, UAuthority, UEntity, UUri};
+use crate::uprotocol::uri::{UAuthority, UEntity, UUri};
 use crate::uri::builder::resourcebuilder::UResourceBuilder;
 use crate::uri::serializer::{SerializationError, UriSerializer};
 use crate::uri::validator::UriValidator;
@@ -37,26 +36,36 @@ impl AddressType {
     fn value(self) -> u8 {
         self as u8
     }
+}
 
-    fn from(value: u8) -> Option<AddressType> {
+impl TryFrom<u8> for AddressType {
+    type Error = SerializationError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0 => Some(AddressType::Local),
-            1 => Some(AddressType::IPv4),
-            2 => Some(AddressType::IPv6),
-            3 => Some(AddressType::ID),
-            _ => None,
+            0 => Ok(AddressType::Local),
+            1 => Ok(AddressType::IPv4),
+            2 => Ok(AddressType::IPv6),
+            3 => Ok(AddressType::ID),
+            _ => Err(SerializationError::new(format!(
+                "unknown address type ID [{}]",
+                value
+            ))),
         }
     }
 }
 
 impl TryFrom<i32> for AddressType {
-    type Error = ();
+    type Error = SerializationError;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         if let Ok(v) = u8::try_from(value) {
-            AddressType::from(v).ok_or(())
+            Self::try_from(v)
         } else {
-            Err(())
+            Err(SerializationError::new(format!(
+                "unknown address type ID [{}]",
+                value
+            )))
         }
     }
 }
@@ -79,22 +88,23 @@ impl UriSerializer<Vec<u8>> for MicroUriSerializer {
             return Err(SerializationError::new("URI is empty or not in micro form"));
         }
 
-        let mut cursor = Cursor::new(Vec::new());
+        let mut buf = vec![];
         let mut address_type = AddressType::Local;
         let mut authority_id: Option<Vec<u8>> = None;
         let mut remote_ip: Option<Vec<u8>> = None;
 
         // UP_VERSION
-        cursor.write_u8(UP_VERSION).unwrap();
+        buf.put_u8(UP_VERSION);
 
         // ADDRESS_TYPE
-        if let Some(authority) = &uri.authority {
-            if authority.remote.is_none() {
+        if let Some(authority) = uri.authority.as_ref() {
+            if authority.get_name().is_none() {
                 address_type = AddressType::Local;
-            } else if let Some(id) = UAuthority::get_id(authority) {
+            }
+            if let Some(id) = authority.get_id() {
                 authority_id = Some(id.to_vec());
                 address_type = AddressType::ID;
-            } else if let Some(ip) = UAuthority::get_ip(authority) {
+            } else if let Some(ip) = authority.get_ip() {
                 match ip.len() {
                     4 => address_type = AddressType::IPv4,
                     16 => address_type = AddressType::IPv6,
@@ -104,18 +114,22 @@ impl UriSerializer<Vec<u8>> for MicroUriSerializer {
             }
         }
 
-        cursor.write_u8(address_type.value()).unwrap();
+        buf.put_u8(address_type.value());
 
         // URESOURCE_ID
         if let Some(id) = uri.resource.as_ref().and_then(|resource| resource.id) {
-            cursor.write_all(&[(id >> 8) as u8]).unwrap();
-            cursor.write_all(&[id as u8]).unwrap();
+            buf.write_all(&[(id >> 8) as u8])
+                .map_err(|e| SerializationError::new(e.to_string()))?;
+            buf.write_all(&[id as u8])
+                .map_err(|e| SerializationError::new(e.to_string()))?;
         }
 
         // UENTITY_ID
         if let Some(id) = uri.entity.as_ref().and_then(|entity| entity.id) {
-            cursor.write_all(&[(id >> 8) as u8]).unwrap();
-            cursor.write_all(&[id as u8]).unwrap();
+            buf.write_all(&[(id >> 8) as u8])
+                .map_err(|e| SerializationError::new(e.to_string()))?;
+            buf.write_all(&[id as u8])
+                .map_err(|e| SerializationError::new(e.to_string()))?;
         }
 
         // UENTITY_VERSION
@@ -124,26 +138,23 @@ impl UriSerializer<Vec<u8>> for MicroUriSerializer {
             .as_ref()
             .and_then(|entity| entity.version_major)
             .unwrap_or(0);
-        cursor.write_u8(version as u8).unwrap();
+        buf.put_u8(version as u8);
 
         // UNUSED
-        cursor.write_u8(0).unwrap();
+        buf.put_u8(0);
 
         // UAUTHORITY
         if address_type != AddressType::Local {
-            if address_type == AddressType::ID && authority_id.is_some() {
-                let len = authority_id.as_ref().unwrap().len() as u8;
-                cursor.write_u8(len).unwrap();
-            }
-
             if let Some(id) = authority_id {
-                cursor.write_all(&id).unwrap();
+                buf.put_u8(id.len() as u8);
+                buf.write_all(&id)
+                    .map_err(|e| SerializationError::new(e.to_string()))?;
             } else if let Some(ip) = remote_ip {
-                cursor.write_all(&ip).unwrap();
+                buf.write_all(&ip)
+                    .map_err(|e| SerializationError::new(e.to_string()))?;
             }
         }
-
-        Ok(cursor.into_inner())
+        Ok(buf)
     }
 
     /// Creates a `UUri` data object from a uProtocol micro URI.
@@ -160,20 +171,17 @@ impl UriSerializer<Vec<u8>> for MicroUriSerializer {
             return Err(SerializationError::new("URI is empty or not in micro form"));
         }
 
+        let mut buf = micro_uri.as_slice();
         // Need to be version 1
-        if micro_uri[0] != 0x1 {
-            return Err(SerializationError::new("URI is not version 1"));
+        if buf.get_u8() != UP_VERSION {
+            return Err(SerializationError::new(format!(
+                "URI is not of expected uProtocol version {}",
+                UP_VERSION
+            )));
         }
+        let address_type = AddressType::try_from(buf.get_u8())?;
 
-        // RESOURCE_ID
-        let uresource_id = u16::from_be_bytes(micro_uri[2..4].try_into().unwrap());
-
-        let address_type = AddressType::from(micro_uri[1]);
-        if address_type.is_none() {
-            return Err(SerializationError::new("Invalid address type"));
-        }
-
-        match address_type.unwrap() {
+        match address_type {
             AddressType::Local => {
                 if micro_uri.len() != LOCAL_MICRO_URI_LENGTH {
                     return Err(SerializationError::new("Invalid micro URI length"));
@@ -189,46 +197,60 @@ impl UriSerializer<Vec<u8>> for MicroUriSerializer {
                     return Err(SerializationError::new("Invalid micro URI length"));
                 }
             }
-            AddressType::ID => {}
+            AddressType::ID => {
+                // we cannot perform any reasonable check at this point because we do not
+                // know the (variable) length of the authority ID yet
+            }
         }
 
-        // UENTITY_ID
-        let ue_id = u16::from_be_bytes(micro_uri[4..6].try_into().unwrap());
+        // RESOURCE
+        let uresource_id = u32::from(buf.get_u16());
+        let resource = Some(UResourceBuilder::from_id(uresource_id));
 
-        // VERSION_ID
-        let ue_version = u32::from(micro_uri[6]);
+        // UENTITY
+        let ue_id = buf.get_u16();
+        let ue_version = u32::from(buf.get_u8());
+        let entity = Some(UEntity {
+            id: Some(ue_id.into()),
+            version_major: Some(ue_version),
+            ..Default::default()
+        });
+
+        // skip unused byte
+        buf.advance(1);
 
         // Calculate uAuthority
-        let mut authority: Option<UAuthority> = None;
-        match address_type.unwrap() {
+        let authority = match address_type {
             AddressType::IPv4 => {
-                let slice: [u8; 4] = micro_uri[8..12].try_into().expect("Wrong slice length");
-                authority = Some(UAuthority {
-                    remote: Some(Remote::Ip(slice.to_vec())),
-                });
+                let ip4_address = buf.copy_to_bytes(4);
+                Some(UAuthority {
+                    ip: Some(ip4_address.into()),
+                    ..Default::default()
+                })
             }
             AddressType::IPv6 => {
-                let slice: [u8; 16] = micro_uri[8..24].try_into().expect("Wrong slice length");
-                authority = Some(UAuthority {
-                    remote: Some(Remote::Ip(slice.to_vec())),
-                });
+                let ip6_address = buf.copy_to_bytes(16);
+                Some(UAuthority {
+                    ip: Some(ip6_address.into()),
+                    ..Default::default()
+                })
             }
             AddressType::ID => {
-                authority = Some(UAuthority {
-                    remote: Some(Remote::Id(micro_uri[9..].to_vec())),
-                });
+                let length = buf.get_u8();
+                let authority_id = buf.copy_to_bytes(length as usize);
+                Some(UAuthority {
+                    id: Some(authority_id.into()),
+                    ..Default::default()
+                })
             }
-            AddressType::Local => {}
-        }
+            AddressType::Local => None,
+        };
 
         Ok(UUri {
-            authority,
-            entity: Some(UEntity {
-                id: Some(ue_id.into()),
-                version_major: Some(ue_version),
-                ..Default::default()
-            }),
-            resource: Some(UResourceBuilder::from_id(u32::from(uresource_id))),
+            authority: authority.into(),
+            entity: entity.into(),
+            resource: resource.into(),
+            ..Default::default()
         })
     }
 }
@@ -238,7 +260,7 @@ mod tests {
     use super::*;
     use std::net::{Ipv4Addr, Ipv6Addr};
 
-    use crate::uprotocol::UResource;
+    use crate::uprotocol::uri::UResource;
     use crate::uri::builder::resourcebuilder::UResourceBuilder;
 
     #[test]
@@ -259,11 +281,13 @@ mod tests {
                 id: Some(29999),
                 version_major: Some(254),
                 ..Default::default()
-            }),
+            })
+            .into(),
             resource: Some(UResource {
                 id: Some(19999),
                 ..Default::default()
-            }),
+            })
+            .into(),
             ..Default::default()
         };
         let uprotocol_uri = MicroUriSerializer::serialize(&uri);
@@ -277,17 +301,22 @@ mod tests {
     fn test_serialize_remote_uri_without_address() {
         let uri = UUri {
             authority: Some(UAuthority {
-                remote: Some(Remote::Name("vcu.vin".to_string())),
-            }),
+                name: Some(String::from("vcu.vin")),
+                ..Default::default()
+            })
+            .into(),
             entity: Some(UEntity {
                 id: Some(29999),
                 version_major: Some(254),
                 ..Default::default()
-            }),
+            })
+            .into(),
             resource: Some(UResource {
                 id: Some(19999),
                 ..Default::default()
-            }),
+            })
+            .into(),
+            ..Default::default()
         };
         let uprotocol_uri = MicroUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_err());
@@ -303,8 +332,9 @@ mod tests {
             entity: Some(UEntity {
                 name: "kaputt".to_string(),
                 ..Default::default()
-            }),
-            resource: Some(UResourceBuilder::for_rpc_response()),
+            })
+            .into(),
+            resource: Some(UResourceBuilder::for_rpc_response()).into(),
             ..Default::default()
         };
         let uprotocol_uri = MicroUriSerializer::serialize(&uri);
@@ -321,7 +351,8 @@ mod tests {
             entity: Some(UEntity {
                 name: "kaputt".to_string(),
                 ..Default::default()
-            }),
+            })
+            .into(),
             ..Default::default()
         };
         let uprotocol_uri = MicroUriSerializer::serialize(&uri);
@@ -347,10 +378,6 @@ mod tests {
         let bad_uri: Vec<u8> = vec![0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0];
         let uprotocol_uri = MicroUriSerializer::deserialize(bad_uri);
         assert!(uprotocol_uri.is_err());
-        assert_eq!(
-            uprotocol_uri.unwrap_err().to_string(),
-            "URI is not version 1"
-        );
     }
 
     #[test]
@@ -358,10 +385,6 @@ mod tests {
         let bad_uri: Vec<u8> = vec![0x1, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0];
         let uprotocol_uri = MicroUriSerializer::deserialize(bad_uri);
         assert!(uprotocol_uri.is_err());
-        assert_eq!(
-            uprotocol_uri.unwrap_err().to_string(),
-            "Invalid address type"
-        );
     }
 
     #[test]
@@ -396,14 +419,18 @@ mod tests {
         let address: Ipv4Addr = "10.0.3.3".parse().unwrap();
         let uri = UUri {
             authority: Some(UAuthority {
-                remote: Some(Remote::Ip(address.octets().to_vec())),
-            }),
+                ip: Some(address.octets().to_vec()),
+                ..Default::default()
+            })
+            .into(),
             entity: Some(UEntity {
                 id: Some(29999),
                 version_major: Some(254),
                 ..Default::default()
-            }),
-            resource: Some(UResourceBuilder::for_rpc_request(None, Some(99))),
+            })
+            .into(),
+            resource: Some(UResourceBuilder::for_rpc_request(None, Some(99))).into(),
+            ..Default::default()
         };
 
         let uprotocol_uri = MicroUriSerializer::serialize(&uri);
@@ -421,17 +448,22 @@ mod tests {
         let address: Ipv6Addr = "2001:0db8:85a3:0000:0000:8a2e:0370:7334".parse().unwrap();
         let uri = UUri {
             authority: Some(UAuthority {
-                remote: Some(Remote::Ip(address.octets().to_vec())),
-            }),
+                ip: Some(address.octets().to_vec()),
+                ..Default::default()
+            })
+            .into(),
             entity: Some(UEntity {
                 id: Some(29999),
                 version_major: Some(254),
                 ..Default::default()
-            }),
+            })
+            .into(),
             resource: Some(UResource {
                 id: Some(19999),
                 ..Default::default()
-            }),
+            })
+            .into(),
+            ..Default::default()
         };
 
         let uprotocol_uri = MicroUriSerializer::serialize(&uri);
@@ -447,33 +479,37 @@ mod tests {
 
     #[test]
     fn test_serialize_id_based_authority() {
-        let size = 13;
-        let bytes: Vec<u8> = (0..size).map(|i| i as u8).collect();
-
+        let authority_id: Vec<u8> = vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09];
         let uri = UUri {
             authority: Some(UAuthority {
-                remote: Some(Remote::Id(bytes)),
-            }),
+                id: Some(authority_id),
+                ..Default::default()
+            })
+            .into(),
             entity: Some(UEntity {
                 id: Some(29999),
                 version_major: Some(254),
                 ..Default::default()
-            }),
+            })
+            .into(),
             resource: Some(UResource {
                 id: Some(19999),
                 ..Default::default()
-            }),
+            })
+            .into(),
+            ..Default::default()
         };
-
-        let uprotocol_uri = MicroUriSerializer::serialize(&uri);
-        assert!(uprotocol_uri.as_ref().is_ok());
-        assert!(!uprotocol_uri.as_ref().unwrap().is_empty());
-        let uri2 = MicroUriSerializer::deserialize(uprotocol_uri.unwrap());
-        assert!(uri2.is_ok());
         assert!(UriValidator::is_micro_form(&uri));
-        assert!(UriValidator::is_micro_form(uri2.as_ref().unwrap()));
-        assert_eq!(uri.to_string(), uri2.as_ref().unwrap().to_string());
-        assert_eq!(uri, uri2.unwrap());
+
+        let serialization_attempt = MicroUriSerializer::serialize(&uri);
+        assert!(serialization_attempt.is_ok());
+        let uprotocol_uri = serialization_attempt.unwrap();
+        assert!(!uprotocol_uri.is_empty());
+        let deserialization_attempt = MicroUriSerializer::deserialize(uprotocol_uri);
+        assert!(deserialization_attempt.is_ok());
+        let uri2 = deserialization_attempt.unwrap();
+        assert!(UriValidator::is_micro_form(&uri2));
+        assert_eq!(uri, uri2);
     }
 
     #[test]
@@ -481,14 +517,18 @@ mod tests {
         let bad_bytes: Vec<u8> = vec![127, 1, 23, 123, 12, 6];
         let uri = UUri {
             authority: Some(UAuthority {
-                remote: Some(Remote::Ip(bad_bytes)),
-            }),
+                ip: Some(bad_bytes),
+                ..Default::default()
+            })
+            .into(),
             entity: Some(UEntity {
                 id: Some(29999),
-                version_major: Some(254),
+                version_major: Some(3),
                 ..Default::default()
-            }),
-            resource: Some(UResourceBuilder::for_rpc_request(None, Some(99))),
+            })
+            .into(),
+            resource: Some(UResourceBuilder::for_rpc_request(None, Some(99))).into(),
+            ..Default::default()
         };
         let uprotocol_uri = MicroUriSerializer::serialize(&uri);
         assert!(uprotocol_uri.is_err());
@@ -502,17 +542,22 @@ mod tests {
 
         let uri = UUri {
             authority: Some(UAuthority {
-                remote: Some(Remote::Id(bytes)),
-            }),
+                id: Some(bytes),
+                ..Default::default()
+            })
+            .into(),
             entity: Some(UEntity {
                 id: Some(29999),
                 version_major: Some(254),
                 ..Default::default()
-            }),
+            })
+            .into(),
             resource: Some(UResource {
                 id: Some(19999),
                 ..Default::default()
-            }),
+            })
+            .into(),
+            ..Default::default()
         };
 
         let uprotocol_uri = MicroUriSerializer::serialize(&uri);

--- a/src/uri/serializer/microuriserializer.rs
+++ b/src/uri/serializer/microuriserializer.rs
@@ -14,7 +14,7 @@
 use bytes::{Buf, BufMut};
 use std::io::Write;
 
-use crate::uprotocol::uri::{UAuthority, UEntity, UUri};
+use crate::uprotocol::{UAuthority, UEntity, UUri};
 use crate::uri::builder::resourcebuilder::UResourceBuilder;
 use crate::uri::serializer::{SerializationError, UriSerializer};
 use crate::uri::validator::UriValidator;
@@ -260,7 +260,7 @@ mod tests {
     use super::*;
     use std::net::{Ipv4Addr, Ipv6Addr};
 
-    use crate::uprotocol::uri::UResource;
+    use crate::uprotocol::UResource;
     use crate::uri::builder::resourcebuilder::UResourceBuilder;
 
     #[test]

--- a/src/uri/serializer/uriserializer.rs
+++ b/src/uri/serializer/uriserializer.rs
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use crate::uprotocol::{Remote, UUri};
+use crate::uprotocol::uri::UUri;
 use crate::uri::serializer::SerializationError;
 use crate::uri::validator::UriValidator;
 
@@ -75,22 +75,23 @@ pub trait UriSerializer<T> {
         let mut ue = micro_uri.entity.unwrap_or_default();
         let mut ure = long_uri.resource.unwrap_or_default();
 
-        if let Some(authority) = long_uri.authority {
-            if let Some(Remote::Name(name)) = authority.remote {
-                auth.remote = Some(Remote::Name(name));
+        if let Some(authority) = long_uri.authority.as_ref() {
+            if let Some(name) = authority.get_name() {
+                auth.name = Some(name.to_owned());
             }
         }
-        if let Some(entity) = long_uri.entity {
-            ue.name = entity.name;
+        if let Some(entity) = long_uri.entity.as_ref() {
+            ue.name = entity.name.clone();
         }
-        if let Some(resource) = micro_uri.resource {
+        if let Some(resource) = micro_uri.resource.as_ref() {
             ure.id = resource.id;
         }
 
         let uri = UUri {
-            authority: Some(auth),
-            entity: Some(ue),
-            resource: Some(ure),
+            authority: Some(auth).into(),
+            entity: Some(ue).into(),
+            resource: Some(ure).into(),
+            ..Default::default()
         };
 
         UriValidator::is_resolved(&uri).then_some(uri)

--- a/src/uri/serializer/uriserializer.rs
+++ b/src/uri/serializer/uriserializer.rs
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use crate::uprotocol::uri::UUri;
+use crate::uprotocol::UUri;
 use crate::uri::serializer::SerializationError;
 use crate::uri::validator::UriValidator;
 

--- a/src/uri/validator/urivalidator.rs
+++ b/src/uri/validator/urivalidator.rs
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use crate::uprotocol::uri::{UAuthority, UUri};
+use crate::uprotocol::{UAuthority, UUri};
 use crate::uri::validator::ValidationError;
 
 /// Struct to encapsulate Uri validation logic.
@@ -241,7 +241,7 @@ mod tests {
     use std::fs;
 
     use crate::{
-        uprotocol::uri::{UEntity, UResource},
+        uprotocol::{UEntity, UResource},
         uri::serializer::{LongUriSerializer, UriSerializer},
     };
 

--- a/src/uuid/builder/uuidbuilder.rs
+++ b/src/uuid/builder/uuidbuilder.rs
@@ -16,7 +16,7 @@ use std::convert::Into;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::uprotocol::uuid::UUID as uproto_Uuid;
+use crate::uprotocol::UUID;
 
 const MAX_COUNT: u64 = 0xfff;
 const MAX_TIMESTAMP_BITS: u8 = 48;
@@ -88,7 +88,7 @@ impl UUIDv8Builder {
     /// if the system time
     /// * is set to a point in time before UNIX Epoch, or
     /// * is set to a point in time later than UNIX Epoch + 0xFFFFFFFFFFFF seconds
-    pub fn build(&self) -> uproto_Uuid {
+    pub fn build(&self) -> UUID {
         if let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) {
             if let Ok(now) = u64::try_from(now.as_millis()) {
                 self.build_with_instant(now)
@@ -109,7 +109,7 @@ impl UUIDv8Builder {
     /// # Panics
     ///
     /// * if the given timestamp is greater than 2^48 - 1.
-    fn build_with_instant(&self, timestamp: u64) -> uproto_Uuid {
+    fn build_with_instant(&self, timestamp: u64) -> UUID {
         assert!(
             timestamp & MAX_TIMESTAMP_MASK == 0,
             "Timestamp of UUID must not exceed 48 bits"

--- a/src/uuid/builder/uuidbuilder.rs
+++ b/src/uuid/builder/uuidbuilder.rs
@@ -16,7 +16,7 @@ use std::convert::Into;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::uprotocol::Uuid as uproto_Uuid;
+use crate::uprotocol::uuid::UUID as uproto_Uuid;
 
 const MAX_COUNT: u64 = 0xfff;
 const MAX_TIMESTAMP_BITS: u8 = 48;


### PR DESCRIPTION
The library now uses the rust-protobuf crate instead
of prost to generate structs from the uProtocol proto files.

All of the library's code has been adapted to the changed API
while trying to maintain the library's existing external behavior.