### PR TITLE
Update GitHub actions depending on deprecated node.js

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: cargo fmt
         working-directory: ${{github.workspace}}
         run: cargo fmt -- --check
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Install dependencies
         run: |


### PR DESCRIPTION
The GitHub workflows have produced a warning message indicating that some of the GitHub Actions used in the workflow had been using a deprecated version of Node.js and should thus be updated ...