### PR TITLE
Update RpcClient::invoke_method() to return a UMessage in support of symmetry / flexibility

### DIFF
--- a/src/rpc/rpcclient.rs
+++ b/src/rpc/rpcclient.rs
@@ -14,9 +14,9 @@
 use async_trait::async_trait;
 
 use crate::rpc::rpcmapper::RpcMapperError;
-use crate::uprotocol::{UAttributes, UPayload, UUri};
+use crate::uprotocol::{UAttributes, UMessage, UPayload, UUri};
 
-pub type RpcClientResult = Result<UPayload, RpcMapperError>;
+pub type RpcClientResult = Result<UMessage, RpcMapperError>;
 
 /// `RpcClient` serves as an interface to be used by code generators for uProtocol services defined in
 /// `.proto` files, such as the core uProtocol services found in

--- a/src/rpc/rpcmapper.rs
+++ b/src/rpc/rpcmapper.rs
@@ -12,7 +12,6 @@
  ********************************************************************************/
 
 use protobuf::well_known_types::any::Any;
-use protobuf::MessageField;
 use protobuf::MessageFull;
 use std::default::Default;
 use std::fmt;
@@ -84,7 +83,7 @@ impl RpcMapper {
         T: MessageFull + Default,
     {
         let message = response?; // Directly returns in case of error
-        let MessageField(Some(payload)) = message.payload else {
+        let Some(payload) = message.payload.as_ref() else {
             return Err(RpcMapperError::InvalidPayload(
                 "Payload is empty".to_string(),
             ));
@@ -129,13 +128,12 @@ impl RpcMapper {
     // TODO This entire thing feels klunky and kludgy; this needs to be revisited...
     pub fn map_response_to_result(response: RpcClientResult) -> RpcPayloadResult {
         let message = response?; // Directly returns in case of error
-        let MessageField(Some(payload)) = message.payload else {
+        let Some(payload) = message.payload.as_ref() else {
             return Err(RpcMapperError::InvalidPayload(
                 "Payload is empty".to_string(),
             ));
         };
-        let payload = *payload;
-        Any::try_from(payload)
+        Any::try_from(*payload)
             .map_err(|e| {
                 RpcMapperError::UnknownType(
                     format!("Couldn't decode payload into Any: {:?}", e).to_string(),

--- a/src/rpc/rpcmapper.rs
+++ b/src/rpc/rpcmapper.rs
@@ -12,8 +12,8 @@
  ********************************************************************************/
 
 use protobuf::well_known_types::any::Any;
-use protobuf::MessageFull;
 use protobuf::MessageField;
+use protobuf::MessageFull;
 use std::default::Default;
 use std::fmt;
 
@@ -85,7 +85,9 @@ impl RpcMapper {
     {
         let message = response?; // Directly returns in case of error
         let MessageField(Some(payload)) = message.payload else {
-            return Err(RpcMapperError::InvalidPayload("Payload is empty".to_string()));
+            return Err(RpcMapperError::InvalidPayload(
+                "Payload is empty".to_string(),
+            ));
         };
         Any::try_from(*payload)
             .map_err(|_e| {
@@ -128,12 +130,16 @@ impl RpcMapper {
     pub fn map_response_to_result(response: RpcClientResult) -> RpcPayloadResult {
         let message = response?; // Directly returns in case of error
         let MessageField(Some(payload)) = message.payload else {
-            return Err(RpcMapperError::InvalidPayload("Payload is empty".to_string()));
+            return Err(RpcMapperError::InvalidPayload(
+                "Payload is empty".to_string(),
+            ));
         };
         let payload = *payload;
         Any::try_from(payload)
             .map_err(|e| {
-                RpcMapperError::UnknownType(format!("Couldn't decode payload into Any: {:?}", e).to_string())
+                RpcMapperError::UnknownType(
+                    format!("Couldn't decode payload into Any: {:?}", e).to_string(),
+                )
             })
             .and_then(|any| {
                 match Self::unpack_any::<UStatus>(&any) {


### PR DESCRIPTION
Hey there :wave: 

As I worked on the uStreamer we figured out we'll need RpcClient::invoke_method() to return a UMessage in order to make the operations performed by the uStreamer upon the CEs coming in and out as generic as possible.

@stevenhartley put out a [spec change](https://github.com/eclipse-uprotocol/up-spec/issues/61) and made the [change over in up-java](https://github.com/eclipse-uprotocol/up-java/pull/74) already. More details can be understood from there.