### PR TITLE
Fix function parameters of UTransport trait

### DIFF
--- a/src/uuid/builder/uuidbuilder.rs
+++ b/src/uuid/builder/uuidbuilder.rs
@@ -43,7 +43,7 @@ impl UUIDv8Builder {
     /// Creates a new builder for creating uProtocol UUIDs.
     ///
     /// The same bulder instance can be used to create one or more UUIDs
-    /// by means of invoking [`UUIDBuilder::build`].
+    /// by means of invoking [`UUIDv8Builder::build`].
     ///
     /// # Examples
     ///


### PR DESCRIPTION
The documentation of the "send" function's parameters has been
adapted to match the semantics of the properties of UMessage.