### PR TITLE
Add convenience functions and examples to UMessageType

### DIFF
--- a/src/cloudevent/builder/ucloudeventbuilder.rs
+++ b/src/cloudevent/builder/ucloudeventbuilder.rs
@@ -96,7 +96,7 @@ impl UCloudEventBuilder {
             attributes,
         )
         .extension("sink", service_method_uri)
-        .ty(UMessageType::UMESSAGE_TYPE_REQUEST)
+        .ty(UMessageType::UMESSAGE_TYPE_REQUEST.to_type_string())
         .build();
 
         bce.unwrap()
@@ -161,7 +161,7 @@ impl UCloudEventBuilder {
         )
         .extension("sink", rpc_uri)
         .extension("reqid", request_id)
-        .ty(UMessageType::UMESSAGE_TYPE_RESPONSE)
+        .ty(UMessageType::UMESSAGE_TYPE_RESPONSE.to_type_string())
         .build();
 
         bce.unwrap()
@@ -227,7 +227,7 @@ impl UCloudEventBuilder {
         .extension("sink", rpc_uri)
         .extension("reqid", request_id)
         .extension("commstatus", i64::from(communication_status))
-        .ty(UMessageType::UMESSAGE_TYPE_RESPONSE)
+        .ty(UMessageType::UMESSAGE_TYPE_RESPONSE.to_type_string())
         .build();
 
         bce.unwrap()
@@ -274,7 +274,7 @@ impl UCloudEventBuilder {
             &payload.type_url,
             attributes,
         )
-        .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+        .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
         .build();
 
         bce.unwrap()
@@ -332,7 +332,7 @@ impl UCloudEventBuilder {
             attributes,
         )
         .extension("sink", sink)
-        .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+        .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
         .build();
 
         bce.unwrap()
@@ -464,7 +464,7 @@ mod tests {
             &proto_payload.type_url,
             &ucloud_event_attributes,
         )
-        .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+        .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
         .build()
         .unwrap();
 
@@ -472,7 +472,7 @@ mod tests {
         assert_eq!("testme", cloud_event.id());
         assert_eq!(source, cloud_event.source().to_string());
         assert_eq!(
-            UMessageType::UMESSAGE_TYPE_PUBLISH.to_string(),
+            UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string(),
             cloud_event.ty()
         );
         assert!(!cloud_event
@@ -533,7 +533,7 @@ mod tests {
             &proto_payload.type_url,
             &ucloud_event_attributes,
         )
-        .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+        .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
         .build()
         .unwrap();
 
@@ -541,7 +541,7 @@ mod tests {
         assert_eq!("testme", cloud_event.id());
         assert_eq!(source, cloud_event.source().to_string());
         assert_eq!(
-            UMessageType::UMESSAGE_TYPE_PUBLISH.to_string(),
+            UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string(),
             cloud_event.ty()
         );
         assert!(!cloud_event
@@ -608,7 +608,7 @@ mod tests {
         assert!(!cloud_event.id().is_empty());
         assert_eq!(source, cloud_event.source().to_string());
         assert_eq!(
-            UMessageType::UMESSAGE_TYPE_PUBLISH.to_string(),
+            UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string(),
             cloud_event.ty()
         );
         assert!(!cloud_event
@@ -704,7 +704,7 @@ mod tests {
             .any(|(name, _value)| name.contains("sink")));
         assert_eq!(sink, cloud_event.extension("sink").unwrap().to_string());
         assert_eq!(
-            UMessageType::UMESSAGE_TYPE_PUBLISH.to_string(),
+            UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string(),
             cloud_event.ty()
         );
         assert_eq!(
@@ -1047,7 +1047,7 @@ mod tests {
         EventBuilderV10::new()
             .id("hello")
             .source("https://example.com")
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .data_with_schema(
                 "application/octet-stream",
                 "proto://type.googleapis.com/example.demo",

--- a/src/cloudevent/builder/ucloudeventutils.rs
+++ b/src/cloudevent/builder/ucloudeventutils.rs
@@ -814,7 +814,7 @@ mod tests {
 
         let builder = cloudevents::EventBuilderV10::new()
             .id("id")
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .source("/body.accss//door.front_left#Door")
             .data_with_schema(
                 UCloudEventBuilder::PROTOBUF_CONTENT_TYPE,
@@ -962,7 +962,7 @@ mod tests {
 
         let builder = cloudevents::EventBuilderV10::new()
             .id("someid")
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .source("/body.accss//door.front_left#Door")
             .data_with_schema(
                 UCloudEventBuilder::PROTOBUF_CONTENT_TYPE,
@@ -985,7 +985,7 @@ mod tests {
 
         let cloud_event = cloudevents::EventBuilderV10::new()
             .id("someId")
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             // The url crate does not accept URLs without a base
             .source(Url::parse("up:/body.access/1/door.front_left#Door").unwrap())
             .data_with_schema(
@@ -1008,7 +1008,7 @@ mod tests {
     fn test_extract_payload_from_cloud_event_when_payload_is_bad_proto_object() {
         let cloud_event = cloudevents::EventBuilderV10::new()
             .id("someId")
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             // The url crate does not accept URLs without a base
             .source(Url::parse("up:/body.access/1/door.front_left#Door").unwrap())
             .data_with_schema(
@@ -1036,7 +1036,7 @@ mod tests {
 
         let cloud_event = cloudevents::EventBuilderV10::new()
             .id("someId")
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .source(Url::parse("up:/body.access/1/door.front_left#Door").unwrap())
             .data(
                 UCloudEventBuilder::PROTOBUF_CONTENT_TYPE,
@@ -1056,7 +1056,7 @@ mod tests {
 
         let cloud_event = cloudevents::EventBuilderV10::new()
             .id("someId")
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .source(Url::parse("up:/body.access/1/door.front_left#Door").unwrap())
             .data_with_schema(
                 UCloudEventBuilder::PROTOBUF_CONTENT_TYPE,
@@ -1076,7 +1076,7 @@ mod tests {
         // Creating a protobuf CloudEvent message
         let source_event = cloudevents::EventBuilderV10::new()
             .id("hello")
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .source(Url::parse("up://VCU.MY_CAR_VIN/someService").unwrap())
             .ty("example.demo")
             .data(
@@ -1092,7 +1092,7 @@ mod tests {
         // Creating the CloudEvent
         let cloud_event = EventBuilderV10::new()
             .id("someId")
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .source(Url::parse("up:/body.access/1/door.front_left#Door").unwrap())
             .data_with_schema(
                 UCloudEventBuilder::PROTOBUF_CONTENT_TYPE,
@@ -1207,7 +1207,7 @@ mod tests {
             payload.type_url.as_str(),
             &attributes,
         );
-        event.ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+        event.ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
     }
 
     fn pack_event_into_any(event: &Event) -> Any {
@@ -1240,7 +1240,7 @@ mod tests {
         EventBuilderV10::new()
             .id("hello")
             .source("//VCU.MY_CAR_VIN/body.access//door.front_left#Door")
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .data_with_schema(
                 "application/octet-stream",
                 "proto://type.googleapis.com/example.demo",

--- a/src/cloudevent/serializer/cloudeventprotobufserializer.rs
+++ b/src/cloudevent/serializer/cloudeventprotobufserializer.rs
@@ -86,7 +86,8 @@ mod tests {
             &proto_payload.type_url,
             &u_cloud_event_attributes,
         );
-        cloud_event_builder = cloud_event_builder.ty(UMessageType::UMESSAGE_TYPE_PUBLISH);
+        cloud_event_builder =
+            cloud_event_builder.ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string());
 
         let cloud_event = cloud_event_builder.build().unwrap();
 
@@ -105,7 +106,7 @@ mod tests {
         // Cloud event
         let cloud_event = EventBuilderV10::new()
             .id("hello")
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .source("/body.access/1/door.front_left".to_string())
             .data_with_schema(
                 "application/protobuf".to_string(),
@@ -118,7 +119,7 @@ mod tests {
         // Another cloud event
         let another_cloud_event = EventBuilderV10::new()
             .id("hello")
-            .ty(UMessageType::UMESSAGE_TYPE_REQUEST)
+            .ty(UMessageType::UMESSAGE_TYPE_REQUEST.to_type_string())
             .source("/body.access/1/door.front_left".to_string())
             .build()
             .unwrap();
@@ -137,7 +138,7 @@ mod tests {
         // Cloud event
         let cloud_event = EventBuilderV10::new()
             .id("hello")
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .source("/body.access/1/door.front_left".to_string())
             .data_with_schema(
                 "application/protobuf".to_string(),
@@ -150,7 +151,7 @@ mod tests {
         // Another cloud event
         let another_cloud_event = EventBuilderV10::new()
             .id("hello")
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .source("/body.access/1/door.front_left".to_string())
             .data_with_schema(
                 "application/protobuf".to_string(),
@@ -209,7 +210,8 @@ mod tests {
             &proto_payload.type_url,
             &u_cloud_event_attributes,
         );
-        cloud_event_builder = cloud_event_builder.ty(UMessageType::UMESSAGE_TYPE_PUBLISH);
+        cloud_event_builder =
+            cloud_event_builder.ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string());
 
         let cloud_event1 = cloud_event_builder.build().unwrap();
         let bytes1 = serializer.serialize(&cloud_event1).unwrap();
@@ -369,7 +371,7 @@ mod tests {
     fn build_cloud_event_for_test() -> EventBuilderV10 {
         EventBuilderV10::new()
             .id("hello")
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .source("//VCU.VIN/body.access")
     }
 
@@ -394,7 +396,7 @@ mod tests {
         let event = EventBuilderV10::new()
             .id("hello")
             .source("//VCU.VIN/body.access")
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .data_with_schema(
                 UCloudEventBuilder::PROTOBUF_CONTENT_TYPE,
                 format!("proto://{}", Any::default().type_url),

--- a/src/cloudevent/validator/cloudeventvalidator.rs
+++ b/src/cloudevent/validator/cloudeventvalidator.rs
@@ -340,7 +340,7 @@ impl CloudEventValidators {
     ///
     /// Returns a `CloudEventValidator` according to the `type` attribute in the `CloudEvent`.
     pub fn get_validator(cloud_event: &Event) -> Box<dyn CloudEventValidator> {
-        match UMessageType::from(cloud_event.ty()) {
+        match UMessageType::from_type_string(cloud_event.ty()) {
             UMessageType::UMESSAGE_TYPE_RESPONSE => Box::new(ResponseValidator),
             UMessageType::UMESSAGE_TYPE_REQUEST => Box::new(RequestValidator),
             _ => Box::new(PublishValidator),
@@ -369,7 +369,8 @@ impl CloudEventValidator for PublishValidator {
     }
 
     fn validate_type(&self, cloud_event: &Event) -> Result<(), ValidationError> {
-        if UMessageType::UMESSAGE_TYPE_PUBLISH.eq(&UMessageType::from(cloud_event.ty())) {
+        if UMessageType::UMESSAGE_TYPE_PUBLISH.eq(&UMessageType::from_type_string(cloud_event.ty()))
+        {
             return Ok(());
         }
         Err(ValidationError::new(format!(
@@ -465,7 +466,8 @@ impl CloudEventValidator for RequestValidator {
     }
 
     fn validate_type(&self, cloud_event: &Event) -> Result<(), ValidationError> {
-        if UMessageType::UMESSAGE_TYPE_REQUEST.eq(&UMessageType::from(cloud_event.ty())) {
+        if UMessageType::UMESSAGE_TYPE_REQUEST.eq(&UMessageType::from_type_string(cloud_event.ty()))
+        {
             return Ok(());
         }
         Err(ValidationError::new(format!(
@@ -522,7 +524,9 @@ impl CloudEventValidator for ResponseValidator {
     }
 
     fn validate_type(&self, cloud_event: &Event) -> Result<(), ValidationError> {
-        if UMessageType::UMESSAGE_TYPE_RESPONSE.eq(&UMessageType::from(cloud_event.ty())) {
+        if UMessageType::UMESSAGE_TYPE_RESPONSE
+            .eq(&UMessageType::from_type_string(cloud_event.ty()))
+        {
             return Ok(());
         }
         Err(ValidationError::new(format!(
@@ -580,7 +584,7 @@ mod tests {
     fn test_publish_cloud_event_type() {
         let builder = build_base_cloud_event_builder_for_test();
         let event = builder
-            .ty(UMessageType::UMESSAGE_TYPE_RESPONSE)
+            .ty(UMessageType::UMESSAGE_TYPE_RESPONSE.to_type_string())
             .build()
             .unwrap();
 
@@ -598,7 +602,7 @@ mod tests {
     fn test_notification_cloud_event_type() {
         let builder = build_base_cloud_event_builder_for_test();
         let event = builder
-            .ty(UMessageType::UMESSAGE_TYPE_RESPONSE)
+            .ty(UMessageType::UMESSAGE_TYPE_RESPONSE.to_type_string())
             .build()
             .unwrap();
 
@@ -617,7 +621,7 @@ mod tests {
     fn test_get_a_request_cloud_event_validator() {
         let builder = build_base_cloud_event_builder_for_test();
         let event = builder
-            .ty(UMessageType::UMESSAGE_TYPE_REQUEST)
+            .ty(UMessageType::UMESSAGE_TYPE_REQUEST.to_type_string())
             .build()
             .unwrap();
 
@@ -632,7 +636,7 @@ mod tests {
     fn test_request_cloud_event_type() {
         let builder = build_base_cloud_event_builder_for_test();
         let event = builder
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .build()
             .unwrap();
 
@@ -650,7 +654,7 @@ mod tests {
     fn test_get_a_response_cloud_event_validator() {
         let builder = build_base_cloud_event_builder_for_test();
         let event = builder
-            .ty(UMessageType::UMESSAGE_TYPE_RESPONSE)
+            .ty(UMessageType::UMESSAGE_TYPE_RESPONSE.to_type_string())
             .build()
             .unwrap();
 
@@ -665,7 +669,7 @@ mod tests {
     fn test_response_cloud_event_type() {
         let builder = build_base_cloud_event_builder_for_test();
         let event = builder
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .build()
             .unwrap();
 
@@ -692,7 +696,7 @@ mod tests {
     fn validate_cloud_event_version_when_valid() {
         let uuid = UUIDv8Builder::new().build();
         let builder = build_base_cloud_event_builder_for_test()
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .id(uuid);
         let event = builder.build().unwrap();
 
@@ -705,7 +709,7 @@ mod tests {
     fn validate_cloud_event_version_when_not_valid() {
         let builder = EventBuilderV03::new()
             .id("id".to_string())
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .source("/body.access".to_string());
 
         let event = builder.build().unwrap();
@@ -723,7 +727,7 @@ mod tests {
     fn validate_cloud_event_id_when_valid() {
         let uuid = UUIDv8Builder::new().build();
         let builder = build_base_cloud_event_builder_for_test()
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .id(uuid);
         let event = builder.build().unwrap();
 
@@ -737,7 +741,7 @@ mod tests {
         let uuid = Uuid::new_v4();
 
         let builder = build_base_cloud_event_builder_for_test()
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .id(uuid);
         let event = builder.build().unwrap();
 
@@ -771,7 +775,7 @@ mod tests {
         let event = build_base_cloud_event_builder_for_test()
             .id(uuid)
             .source("/body.access/1/door.front_left#Door".to_string())
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .build()
             .unwrap();
 
@@ -791,7 +795,7 @@ mod tests {
         let event = build_base_cloud_event_builder_for_test()
             .id(uuid)
             .source(uri)
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .build();
         let event = event.unwrap();
 
@@ -813,7 +817,7 @@ mod tests {
             .id(uuid)
             .source(uri)
             .extension("sink", sink.to_string())
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .build()
             .unwrap();
 
@@ -831,7 +835,7 @@ mod tests {
             .id(uuid)
             .source(uri)
             .extension("sink", sink.to_string())
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .build()
             .unwrap();
 
@@ -851,7 +855,7 @@ mod tests {
         let event = build_base_cloud_event_builder_for_test()
             .id(uuid)
             .source("/".to_string())
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .build()
             .unwrap();
 
@@ -872,7 +876,7 @@ mod tests {
         let event = build_base_cloud_event_builder_for_test()
             .id("testme".to_string())
             .source(uri)
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .build()
             .unwrap();
 
@@ -899,7 +903,7 @@ mod tests {
         let event = build_base_cloud_event_builder_for_test()
             .id("testme".to_string())
             .source(uri)
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .build()
             .unwrap();
 
@@ -928,7 +932,7 @@ mod tests {
             .id(uuid)
             .source(uri)
             .extension("sink", sink.to_string())
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .build()
             .unwrap();
 
@@ -945,7 +949,7 @@ mod tests {
         let event = build_base_cloud_event_builder_for_test()
             .id(uuid)
             .source(uri.to_string())
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .build()
             .unwrap();
 
@@ -965,7 +969,7 @@ mod tests {
             .id(uuid)
             .source(uri.to_string())
             .extension("sink", sink.to_string())
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .build()
             .unwrap();
 
@@ -984,7 +988,7 @@ mod tests {
             .id(uuid)
             .source(source)
             .extension("sink", sink.to_string())
-            .ty(UMessageType::UMESSAGE_TYPE_REQUEST)
+            .ty(UMessageType::UMESSAGE_TYPE_REQUEST.to_type_string())
             .build()
             .unwrap();
 
@@ -1003,7 +1007,7 @@ mod tests {
             .id(uuid)
             .source(source)
             .extension("sink", sink.to_string())
-            .ty(UMessageType::UMESSAGE_TYPE_REQUEST)
+            .ty(UMessageType::UMESSAGE_TYPE_REQUEST.to_type_string())
             .build()
             .unwrap();
 
@@ -1024,7 +1028,7 @@ mod tests {
         let event = build_base_cloud_event_builder_for_test()
             .id(uuid)
             .source(source)
-            .ty(UMessageType::UMESSAGE_TYPE_REQUEST)
+            .ty(UMessageType::UMESSAGE_TYPE_REQUEST.to_type_string())
             .build()
             .unwrap();
 
@@ -1047,7 +1051,7 @@ mod tests {
             .id(uuid)
             .source(source)
             .extension("sink", sink.to_string())
-            .ty(UMessageType::UMESSAGE_TYPE_REQUEST)
+            .ty(UMessageType::UMESSAGE_TYPE_REQUEST.to_type_string())
             .build()
             .unwrap();
 
@@ -1070,7 +1074,7 @@ mod tests {
             .id(uuid)
             .source(source)
             .extension("sink", sink.to_string())
-            .ty(UMessageType::UMESSAGE_TYPE_RESPONSE)
+            .ty(UMessageType::UMESSAGE_TYPE_RESPONSE.to_type_string())
             .build()
             .unwrap();
 
@@ -1089,7 +1093,7 @@ mod tests {
             .id(uuid)
             .source(source)
             .extension("sink", sink.to_string())
-            .ty(UMessageType::UMESSAGE_TYPE_RESPONSE)
+            .ty(UMessageType::UMESSAGE_TYPE_RESPONSE.to_type_string())
             .build()
             .unwrap();
 
@@ -1110,7 +1114,7 @@ mod tests {
         let event = build_base_cloud_event_builder_for_test()
             .id(uuid)
             .source(source)
-            .ty(UMessageType::UMESSAGE_TYPE_RESPONSE)
+            .ty(UMessageType::UMESSAGE_TYPE_RESPONSE.to_type_string())
             .build()
             .unwrap();
 
@@ -1133,7 +1137,7 @@ mod tests {
             .id(uuid)
             .source(source)
             .extension("sink", sink.to_string())
-            .ty(UMessageType::UMESSAGE_TYPE_RESPONSE)
+            .ty(UMessageType::UMESSAGE_TYPE_RESPONSE.to_type_string())
             .build()
             .unwrap();
 
@@ -1184,7 +1188,7 @@ mod tests {
 
     fn build_base_cloud_event_for_test() -> Event {
         let mut builder = build_base_cloud_event_builder_for_test();
-        builder = builder.ty(UMessageType::UMESSAGE_TYPE_PUBLISH);
+        builder = builder.ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string());
         builder.build().unwrap()
     }
 
@@ -1192,7 +1196,7 @@ mod tests {
         let event = EventBuilderV10::new()
             .id("hello")
             .source("/body.access")
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .data_with_schema(
                 "application/octet-stream",
                 "proto://type.googleapis.com/example.demo",

--- a/src/proto/cloudevents/protocloudevent.rs
+++ b/src/proto/cloudevents/protocloudevent.rs
@@ -272,7 +272,7 @@ mod tests {
             payload.type_url.as_str(),
             &attributes,
         );
-        event.ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+        event.ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
     }
 
     fn pack_event_into_any(event: &Event) -> Any {
@@ -305,7 +305,7 @@ mod tests {
         EventBuilderV10::new()
             .id("hello")
             .source("//VCU.MY_CAR_VIN/body.access//door.front_left#Door")
-            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH)
+            .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .data_with_schema(
                 "application/octet-stream",
                 "proto://type.googleapis.com/example.demo",

--- a/src/proto/uprotocol/umessagetype.rs
+++ b/src/proto/uprotocol/umessagetype.rs
@@ -11,34 +11,110 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use std::fmt::Display;
+use protobuf::Enum;
 
 use crate::uprotocol::uattributes::UMessageType;
 
-impl From<UMessageType> for String {
-    fn from(value: UMessageType) -> Self {
-        value.to_string()
-    }
-}
+const MESSAGE_TYPE_PUBLISH: &str = "pub.v1";
+const MESSAGE_TYPE_REQUEST: &str = "req.v1";
+const MESSAGE_TYPE_RESPONSE: &str = "res.v1";
+const MESSAGE_TYPE_UNSPECIFIED: &str = "unspec.v1";
 
-impl From<&str> for UMessageType {
-    fn from(value: &str) -> Self {
-        match value {
-            "pub.v1" => UMessageType::UMESSAGE_TYPE_PUBLISH,
-            "req.v1" => UMessageType::UMESSAGE_TYPE_REQUEST,
-            "res.v1" => UMessageType::UMESSAGE_TYPE_RESPONSE,
-            _ => UMessageType::UMESSAGE_TYPE_UNSPECIFIED,
+impl UMessageType {
+    /// Gets this message type's integer code as a [`String`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uprotocol_sdk::uprotocol::UMessageType;
+    ///
+    /// assert_eq!(UMessageType::UMESSAGE_TYPE_PUBLISH.to_i32_string(), "1");
+    /// ```
+    pub fn to_i32_string(&self) -> String {
+        self.value().to_string()
+    }
+
+    /// Gets the message type for an integer encoded as a string.
+    ///
+    /// # Returns
+    ///
+    /// [`UMessageType::UMESSAGE_TYPE_UNSPECIFIED`] if the string cannot be parsed
+    /// into an [`i32`] or the integer does not match any of the supported message types.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uprotocol_sdk::uprotocol::UMessageType;
+    ///
+    /// let message_type = UMessageType::from_i32_string("1");
+    /// assert_eq!(message_type, UMessageType::UMESSAGE_TYPE_PUBLISH);
+    ///
+    /// let message_type = UMessageType::from_i32_string("16");
+    /// assert_eq!(message_type, UMessageType::UMESSAGE_TYPE_UNSPECIFIED);
+    ///
+    /// let message_type = UMessageType::from_i32_string("foo.bar");
+    /// assert_eq!(message_type, UMessageType::UMESSAGE_TYPE_UNSPECIFIED);
+    /// ```
+    pub fn from_i32_string<S: Into<String>>(value: S) -> Self {
+        if let Ok(code) = value.into().parse::<i32>() {
+            UMessageType::from_i32(code).unwrap_or(UMessageType::UMESSAGE_TYPE_UNSPECIFIED)
+        } else {
+            UMessageType::UMESSAGE_TYPE_UNSPECIFIED
         }
     }
-}
 
-impl Display for UMessageType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    /// Gets this message type's string identifier.
+    ///
+    /// # Returns
+    ///
+    /// A stable identifier which can be used to encode a message type and decode it
+    /// again using [`UMessageType::from_type_string`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uprotocol_sdk::uprotocol::UMessageType;
+    ///
+    /// let identifier = UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string();
+    /// assert_eq!(identifier, "pub.v1");
+    ///
+    /// let message_type = UMessageType::from_type_string(identifier);
+    /// assert_eq!(message_type, UMessageType::UMESSAGE_TYPE_PUBLISH);
+    /// ```
+    pub fn to_type_string(&self) -> &'static str {
         match self {
-            UMessageType::UMESSAGE_TYPE_PUBLISH => write!(f, "pub.v1"),
-            UMessageType::UMESSAGE_TYPE_REQUEST => write!(f, "req.v1"),
-            UMessageType::UMESSAGE_TYPE_RESPONSE => write!(f, "res.v1"),
-            UMessageType::UMESSAGE_TYPE_UNSPECIFIED => write!(f, "unspec.v1"),
+            UMessageType::UMESSAGE_TYPE_PUBLISH => MESSAGE_TYPE_PUBLISH,
+            UMessageType::UMESSAGE_TYPE_REQUEST => MESSAGE_TYPE_REQUEST,
+            UMessageType::UMESSAGE_TYPE_RESPONSE => MESSAGE_TYPE_RESPONSE,
+            UMessageType::UMESSAGE_TYPE_UNSPECIFIED => MESSAGE_TYPE_UNSPECIFIED,
+        }
+    }
+
+    /// Gets the message type for a string identifier.
+    ///
+    /// # Returns
+    ///
+    /// [`UMessageType::UMESSAGE_TYPE_UNSPECIFIED`] if the identifier does not match
+    /// any of the supported message types.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uprotocol_sdk::uprotocol::UMessageType;
+    ///
+    /// let message_type = UMessageType::from_type_string("pub.v1");
+    /// assert_eq!(message_type, UMessageType::UMESSAGE_TYPE_PUBLISH);
+    ///
+    /// let message_type = UMessageType::from_type_string("foo.bar");
+    /// assert_eq!(message_type, UMessageType::UMESSAGE_TYPE_UNSPECIFIED);
+    /// ```
+    pub fn from_type_string<S: Into<String>>(value: S) -> Self {
+        let type_string = value.into();
+        match type_string.as_str() {
+            MESSAGE_TYPE_PUBLISH => UMessageType::UMESSAGE_TYPE_PUBLISH,
+            MESSAGE_TYPE_REQUEST => UMessageType::UMESSAGE_TYPE_REQUEST,
+            MESSAGE_TYPE_RESPONSE => UMessageType::UMESSAGE_TYPE_RESPONSE,
+            _ => UMessageType::UMESSAGE_TYPE_UNSPECIFIED,
         }
     }
 }

--- a/src/rpc/rpcmapper.rs
+++ b/src/rpc/rpcmapper.rs
@@ -326,7 +326,7 @@ mod tests {
     fn build_cloud_event_for_test() -> Event {
         EventBuilderV10::new()
             .id("hello")
-            .ty(UMessageType::UMESSAGE_TYPE_REQUEST)
+            .ty(UMessageType::UMESSAGE_TYPE_REQUEST.to_type_string())
             .source("http://example.com")
             .build()
             .unwrap()

--- a/src/transport/validator/uattributesvalidator.rs
+++ b/src/transport/validator/uattributesvalidator.rs
@@ -340,7 +340,7 @@ impl UAttributesValidator for PublishValidator {
                 UMessageType::UMESSAGE_TYPE_PUBLISH => Ok(()),
                 _ => Err(ValidationError::new(format!(
                     "Wrong Attribute Type [{}]",
-                    mt
+                    mt.to_type_string()
                 ))),
             },
         }
@@ -374,7 +374,7 @@ impl UAttributesValidator for RequestValidator {
                 UMessageType::UMESSAGE_TYPE_REQUEST => Ok(()),
                 _ => Err(ValidationError::new(format!(
                     "Wrong Attribute Type [{}]",
-                    mt
+                    mt.to_type_string()
                 ))),
             },
         }
@@ -448,7 +448,7 @@ impl UAttributesValidator for ResponseValidator {
                 UMessageType::UMESSAGE_TYPE_RESPONSE => Ok(()),
                 _ => Err(ValidationError::new(format!(
                     "Wrong Attribute Type [{}]",
-                    mt
+                    mt.to_type_string()
                 ))),
             },
         }


### PR DESCRIPTION
Added functions for mapping message types to/from string encoded integers and type strings. These should be helpful when encoding the message type to a property of a transport layer PDU.

Also removed the implementation for Display which might have been mistaken to produce a UMessageType's stable string encoding.