### PR TITLE
String-Uri conversions can now fail

### DIFF
--- a/src/proto/uprotocol/uuri.rs
+++ b/src/proto/uprotocol/uuri.rs
@@ -11,19 +11,19 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use crate::uprotocol::uri::UUri as uproto_Uuri;
+use crate::uprotocol::uri::UUri;
 use crate::uprotocol::SerializationError;
 use crate::uri::serializer::{LongUriSerializer, MicroUriSerializer, UriSerializer};
 
-impl TryFrom<uproto_Uuri> for String {
+impl TryFrom<UUri> for String {
     type Error = SerializationError;
 
-    fn try_from(value: uproto_Uuri) -> Result<Self, Self::Error> {
+    fn try_from(value: UUri) -> Result<Self, Self::Error> {
         LongUriSerializer::serialize(&value)
     }
 }
 
-impl TryFrom<&str> for uproto_Uuri {
+impl TryFrom<&str> for UUri {
     type Error = SerializationError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
@@ -31,15 +31,15 @@ impl TryFrom<&str> for uproto_Uuri {
     }
 }
 
-impl TryFrom<uproto_Uuri> for Vec<u8> {
+impl TryFrom<UUri> for Vec<u8> {
     type Error = SerializationError;
 
-    fn try_from(value: uproto_Uuri) -> Result<Self, Self::Error> {
+    fn try_from(value: UUri) -> Result<Self, Self::Error> {
         MicroUriSerializer::serialize(&value)
     }
 }
 
-impl TryFrom<Vec<u8>> for uproto_Uuri {
+impl TryFrom<Vec<u8>> for UUri {
     type Error = SerializationError;
 
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {

--- a/src/proto/uprotocol/uuri.rs
+++ b/src/proto/uprotocol/uuri.rs
@@ -12,44 +12,37 @@
  ********************************************************************************/
 
 use crate::uprotocol::uri::UUri as uproto_Uuri;
+use crate::uprotocol::SerializationError;
 use crate::uri::serializer::{LongUriSerializer, MicroUriSerializer, UriSerializer};
 
-impl From<uproto_Uuri> for String {
-    fn from(value: uproto_Uuri) -> Self {
-        if let Ok(uri) = LongUriSerializer::serialize(&value) {
-            uri
-        } else {
-            String::new()
-        }
+impl TryFrom<uproto_Uuri> for String {
+    type Error = SerializationError;
+
+    fn try_from(value: uproto_Uuri) -> Result<Self, Self::Error> {
+        LongUriSerializer::serialize(&value)
     }
 }
 
-impl From<&str> for uproto_Uuri {
-    fn from(value: &str) -> Self {
-        if let Ok(uri) = LongUriSerializer::deserialize(value.to_string()) {
-            uri
-        } else {
-            uproto_Uuri::default()
-        }
+impl TryFrom<&str> for uproto_Uuri {
+    type Error = SerializationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        LongUriSerializer::deserialize(value.into())
     }
 }
 
-impl From<uproto_Uuri> for Vec<u8> {
-    fn from(value: uproto_Uuri) -> Self {
-        if let Ok(uri) = MicroUriSerializer::serialize(&value) {
-            uri
-        } else {
-            vec![]
-        }
+impl TryFrom<uproto_Uuri> for Vec<u8> {
+    type Error = SerializationError;
+
+    fn try_from(value: uproto_Uuri) -> Result<Self, Self::Error> {
+        MicroUriSerializer::serialize(&value)
     }
 }
 
-impl From<Vec<u8>> for uproto_Uuri {
-    fn from(value: Vec<u8>) -> Self {
-        if let Ok(uri) = MicroUriSerializer::deserialize(value) {
-            uri
-        } else {
-            uproto_Uuri::default()
-        }
+impl TryFrom<Vec<u8>> for uproto_Uuri {
+    type Error = SerializationError;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        MicroUriSerializer::deserialize(value)
     }
 }

--- a/src/uri/serializer/longuriserializer.rs
+++ b/src/uri/serializer/longuriserializer.rs
@@ -1203,10 +1203,7 @@ mod tests {
 
     #[test]
     fn test_deserialize_long_and_micro_passing_empty_long_uri_empty_byte_array() {
-        let uri = LongUriSerializer::build_resolved("", &[]);
-        assert!(uri.is_some());
-        let uri2 = LongUriSerializer::serialize(&uri.unwrap());
-        assert!(uri2.is_err());
-        assert_eq!(uri2.unwrap_err().to_string(), "URI is empty");
+        let uri: Result<UUri, SerializationError> = LongUriSerializer::build_resolved("", &[]);
+        assert!(uri.is_err());
     }
 }

--- a/src/uri/serializer/uriserializer.rs
+++ b/src/uri/serializer/uriserializer.rs
@@ -41,22 +41,22 @@ pub trait UriSerializer<T> {
     /// Serializes a `UUri` into a specific serialization format.
     ///
     /// # Arguments
-    /// * `uri` - The `UUri` object to be serialized into the format `T`.
+    /// * `uri` - The uri object to be serialized into the format `T`.
     ///
     /// # Returns
-    /// Returns a `Result<T, SerializationError>` representing the serialized `UUri` in the specified format.
+    /// Returns the serialized uri in the specified format.
     ///
     /// # Errors
     ///
     /// Returns a `SerializationError` if the serialization process fails. This may be due to reasons such as incompatible data
-    /// in the `UUri` that cannot be represented in the desired format, or errors that occur during the serialization process.
+    /// in the uri that cannot be represented in the desired format, or errors that occur during the serialization process.
     fn serialize(uri: &UUri) -> Result<T, SerializationError>;
 
     /// Builds a fully resolved `UUri` from the serialized long format and the serialized micro format.
     ///
     /// # Arguments
-    /// * `long_uri` - `UUri` serialized as a string.
-    /// * `micro_uri` - `UUri` serialized as a byte slice.
+    /// * `long_uri` - uri serialized as a string.
+    /// * `micro_uri` - uri serialized as a byte slice.
     ///
     /// # Returns
     /// Returns an `Option<UUri>` object serialized from one of the forms. Returns `None` if the URI
@@ -68,8 +68,14 @@ pub trait UriSerializer<T> {
             });
         }
 
-        let long_uri = UUri::from(long_uri);
-        let micro_uri = UUri::from(micro_uri.to_vec());
+        let long_uri: UUri = match UUri::try_from(long_uri) {
+            Ok(uri) => uri,
+            Err(_) => return None,
+        };
+        let micro_uri: UUri = match UUri::try_from(micro_uri.to_vec()) {
+            Ok(uri) => uri,
+            Err(_) => return None,
+        };
 
         let mut auth = micro_uri.authority.unwrap_or_default();
         let mut ue = micro_uri.entity.unwrap_or_default();


### PR DESCRIPTION
String-Uri conversions can now fail, instead of silently returning (empty) default objects.