### PR TITLE
Rename UUIDv8Builder to UUIDBuilder

### DIFF
--- a/src/cloudevent/builder/ucloudeventbuilder.rs
+++ b/src/cloudevent/builder/ucloudeventbuilder.rs
@@ -19,7 +19,7 @@ use url::{ParseError, Url};
 
 use crate::cloudevent::datamodel::UCloudEventAttributes;
 use crate::uprotocol::UMessageType;
-use crate::uuid::builder::UUIDv8Builder;
+use crate::uuid::builder::UUIDBuilder;
 
 pub struct UCloudEventBuilder;
 
@@ -38,7 +38,7 @@ impl UCloudEventBuilder {
     /// Creates the string representation of a `UUIDv8` as defined by
     /// [RFC 4122](https://www.rfc-editor.org/rfc/rfc4122.html#section-3)
     fn create_cloudevent_id() -> String {
-        UUIDv8Builder::new().build().to_hyphenated_string()
+        UUIDBuilder::new().build().to_hyphenated_string()
     }
 
     /// Creates a `CloudEvent` for an event for the use case of an RPC Request message.

--- a/src/cloudevent/builder/ucloudeventutils.rs
+++ b/src/cloudevent/builder/ucloudeventutils.rs
@@ -492,7 +492,7 @@ mod tests {
     use crate::cloudevents::CloudEvent;
     use crate::uprotocol::{UEntity, UMessageType, UPriority, UResource, UUri};
     use crate::uri::serializer::{LongUriSerializer, UriSerializer};
-    use crate::uuid::builder::UUIDv8Builder;
+    use crate::uuid::builder::UUIDBuilder;
 
     use chrono::{offset, TimeZone, Utc};
     use cloudevents::{Data, Event, EventBuilder, EventBuilderV10};
@@ -757,7 +757,7 @@ mod tests {
 
     #[test]
     fn test_extract_creation_timestamp_from_cloud_event_uuidv8_id_when_uuidv8_id_is_valid() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let builder = build_base_cloud_event_for_test();
         let cloud_event = builder.id(uuid).build().unwrap();
 
@@ -890,7 +890,7 @@ mod tests {
 
     #[test]
     fn test_cloudevent_is_not_expired_when_ttl_is_minus_one() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let builder = build_base_cloud_event_for_test()
             .extension("ttl", -1)
             .id(uuid);
@@ -901,7 +901,7 @@ mod tests {
 
     #[test]
     fn test_cloudevent_is_not_expired_when_ttl_is_large_number_mili() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let builder = build_base_cloud_event_for_test()
             .extension("ttl", i64::MAX)
             .id(uuid);
@@ -915,7 +915,7 @@ mod tests {
         use std::thread;
         use std::time::Duration;
 
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let builder = build_base_cloud_event_for_test()
             .extension("ttl", 1)
             .id(uuid);
@@ -928,7 +928,7 @@ mod tests {
 
     #[test]
     fn test_cloudevent_has_a_v8_uuid() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let builder = build_base_cloud_event_for_test().id(uuid);
         let cloud_event = builder.build().unwrap();
 

--- a/src/cloudevent/validator/cloudeventvalidator.rs
+++ b/src/cloudevent/validator/cloudeventvalidator.rs
@@ -547,7 +547,7 @@ mod tests {
     use crate::cloudevent::builder::UCloudEventBuilder;
     use crate::cloudevent::datamodel::UCloudEventAttributesBuilder;
     use crate::uprotocol::{UAuthority, UEntity, UPriority};
-    use crate::uuid::builder::UUIDv8Builder;
+    use crate::uuid::builder::UUIDBuilder;
 
     use super::*;
 
@@ -694,7 +694,7 @@ mod tests {
 
     #[test]
     fn validate_cloud_event_version_when_valid() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let builder = build_base_cloud_event_builder_for_test()
             .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .id(uuid);
@@ -725,7 +725,7 @@ mod tests {
 
     #[test]
     fn validate_cloud_event_id_when_valid() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let builder = build_base_cloud_event_builder_for_test()
             .ty(UMessageType::UMESSAGE_TYPE_PUBLISH.to_type_string())
             .id(uuid);
@@ -771,7 +771,7 @@ mod tests {
 
     #[test]
     fn test_publish_type_cloudevent_is_valid_when_everything_is_valid_local() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let event = build_base_cloud_event_builder_for_test()
             .id(uuid)
             .source("/body.access/1/door.front_left#Door".to_string())
@@ -790,7 +790,7 @@ mod tests {
 
     #[test]
     fn test_publish_type_cloudevent_is_valid_when_everything_is_valid_remote() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let uri = "//VCU.myvin/body.access/1/door.front_left#Door";
         let event = build_base_cloud_event_builder_for_test()
             .id(uuid)
@@ -810,7 +810,7 @@ mod tests {
 
     #[test]
     fn test_publish_type_cloudevent_is_valid_when_everything_is_valid_remote_with_a_sink() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let uri = "//VCU.myvin/body.access/1/door.front_left#Door";
         let sink = "//bo.cloud/petapp";
         let event = build_base_cloud_event_builder_for_test()
@@ -828,7 +828,7 @@ mod tests {
 
     #[test]
     fn test_publish_type_cloudevent_is_not_valid_when_remote_with_invalid_sink() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let uri = "//VCU.myvin/body.access/1/door.front_left#Door";
         let sink = "//bo.cloud";
         let event = build_base_cloud_event_builder_for_test()
@@ -851,7 +851,7 @@ mod tests {
 
     #[test]
     fn test_publish_type_cloudevent_is_not_valid_when_source_is_empty() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let event = build_base_cloud_event_builder_for_test()
             .id(uuid)
             .source("/".to_string())
@@ -925,7 +925,7 @@ mod tests {
 
     #[test]
     fn test_notification_type_cloudevent_is_valid_when_everything_is_valid() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let uri = "/body.access/1/door.front_left#Door";
         let sink = "//bo.cloud/petapp";
         let event = build_base_cloud_event_builder_for_test()
@@ -943,7 +943,7 @@ mod tests {
 
     #[test]
     fn test_notification_type_cloudevent_is_not_valid_missing_sink() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let uri = LongUriSerializer::deserialize("/body.access/1/door.front_left#Door".to_string())
             .unwrap();
         let event = build_base_cloud_event_builder_for_test()
@@ -961,7 +961,7 @@ mod tests {
 
     #[test]
     fn test_notification_type_cloudevent_is_not_valid_invalid_sink() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let uri = LongUriSerializer::deserialize("/body.access/1/door.front_left#Door".to_string())
             .unwrap();
         let sink = LongUriSerializer::deserialize("//bo.cloud".to_string()).unwrap();
@@ -981,7 +981,7 @@ mod tests {
 
     #[test]
     fn test_request_type_cloudevent_is_valid_when_everything_is_valid() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let source = "//bo.cloud/petapp//rpc.response";
         let sink = "//VCU.myvin/body.access/1/rpc.UpdateDoor";
         let event = build_base_cloud_event_builder_for_test()
@@ -1000,7 +1000,7 @@ mod tests {
 
     #[test]
     fn test_request_type_cloudevent_is_not_valid_invalid_source() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let source = "//bo.cloud/petapp//dog";
         let sink = "//VCU.myvin/body.access/1/rpc.UpdateDoor";
         let event = build_base_cloud_event_builder_for_test()
@@ -1023,7 +1023,7 @@ mod tests {
 
     #[test]
     fn test_request_type_cloudevent_is_not_valid_missing_sink() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let source = "//bo.cloud/petapp//rpc.response";
         let event = build_base_cloud_event_builder_for_test()
             .id(uuid)
@@ -1044,7 +1044,7 @@ mod tests {
 
     #[test]
     fn test_request_type_cloudevent_is_not_valid_invalid_sink_not_rpc_command() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let source = "//bo.cloud/petapp//rpc.response";
         let sink = "//VCU.myvin/body.access/1/UpdateDoor";
         let event = build_base_cloud_event_builder_for_test()
@@ -1067,7 +1067,7 @@ mod tests {
 
     #[test]
     fn test_response_type_cloudevent_is_valid_when_everything_is_valid() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let source = "//VCU.myvin/body.access/1/rpc.UpdateDoor";
         let sink = "//bo.cloud/petapp//rpc.response";
         let event = build_base_cloud_event_builder_for_test()
@@ -1086,7 +1086,7 @@ mod tests {
 
     #[test]
     fn test_response_type_cloudevent_is_not_valid_invalid_source() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let source = "//VCU.myvin/body.access/1/UpdateDoor";
         let sink = "//bo.cloud/petapp//rpc.response";
         let event = build_base_cloud_event_builder_for_test()
@@ -1109,7 +1109,7 @@ mod tests {
 
     #[test]
     fn test_response_type_cloudevent_is_not_valid_missing_sink_and_invalid_source() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let source = "//VCU.myvin/body.access/1/UpdateDoor";
         let event = build_base_cloud_event_builder_for_test()
             .id(uuid)
@@ -1130,7 +1130,7 @@ mod tests {
 
     #[test]
     fn test_response_type_cloudevent_is_not_valid_invalid_source_not_rpc_command() {
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let source = "//bo.cloud/petapp/1/dog";
         let sink = "//VCU.myvin/body.access/1/UpdateDoor";
         let event = build_base_cloud_event_builder_for_test()

--- a/src/proto/cloudevents/protocloudevent.rs
+++ b/src/proto/cloudevents/protocloudevent.rs
@@ -291,7 +291,7 @@ mod tests {
     use crate::uprotocol::uri::{UEntity, UResource, UUri};
     use crate::uprotocol::{UAttributes, UAuthority, UPayload, UPayloadFormat};
     use crate::uri::serializer::{LongUriSerializer, UriSerializer};
-    use crate::uuid::builder::UUIDv8Builder;
+    use crate::uuid::builder::UUIDBuilder;
 
     use cloudevents::{Event, EventBuilder, EventBuilderV10};
     use protobuf::well_known_types::any::Any;
@@ -343,7 +343,7 @@ mod tests {
             .into(),
             ..Default::default()
         };
-        let uuid = UUIDv8Builder::new().build();
+        let uuid = UUIDBuilder::new().build();
         let payload = UPayload {
             data: Some(crate::uprotocol::upayload::upayload::Data::Value(
                 Any::default().value,

--- a/src/transport/builder/uattributesbuilder.rs
+++ b/src/transport/builder/uattributesbuilder.rs
@@ -12,7 +12,7 @@
  ********************************************************************************/
 
 use crate::uprotocol::{UAttributes, UMessageType, UPriority, UUri, UUID};
-use crate::uuid::builder::UUIDv8Builder;
+use crate::uuid::builder::UUIDBuilder;
 
 /// Builder for easy construction of the `UAttributes` object.
 pub struct UAttributesBuilder {
@@ -28,18 +28,21 @@ pub struct UAttributesBuilder {
 }
 
 impl UAttributesBuilder {
-    /// Gets a builder for creating a publish message.
+    /// Gets a builder for creating a publish message with a given priority.
     ///
-    /// # Arguments
+    /// # Examples
     ///
-    /// * `priority` - The priority of the message.
+    /// ```rust
+    /// use up_rust::uprotocol::{UMessageType, UPriority};
+    /// use up_rust::transport::builder::UAttributesBuilder;
     ///
-    /// # Returns
-    ///
-    /// The builder initialized with the given values.
+    /// let attributes = UAttributesBuilder::publish(UPriority::UPRIORITY_CS2).build();
+    /// assert_eq!(attributes.type_, UMessageType::UMESSAGE_TYPE_PUBLISH.into());
+    /// assert_eq!(attributes.priority, UPriority::UPRIORITY_CS2.into());
+    /// ```
     pub fn publish(priority: UPriority) -> UAttributesBuilder {
         UAttributesBuilder {
-            id: UUIDv8Builder::new().build(),
+            id: UUIDBuilder::new().build(),
             message_type: UMessageType::UMESSAGE_TYPE_PUBLISH,
             priority,
             ttl: None,
@@ -51,19 +54,23 @@ impl UAttributesBuilder {
         }
     }
 
-    /// Gets a builder for creating a notification message.
+    /// Gets a builder for creating a notification message with a given priority and origin.
     ///
-    /// # Arguments
+    /// # Examples
     ///
-    /// * `priority` - The priority of the message.
-    /// * `sink` - The destination URI.
+    /// ```rust
+    /// use up_rust::uprotocol::{UMessageType, UPriority, UUri};
+    /// use up_rust::transport::builder::UAttributesBuilder;
     ///
-    /// # Returns
-    ///
-    /// The builder initialized with the given values.
+    /// let origin = UUri::default();
+    /// let attributes = UAttributesBuilder::notification(UPriority::UPRIORITY_CS2, origin.clone()).build();
+    /// assert_eq!(attributes.type_, UMessageType::UMESSAGE_TYPE_PUBLISH.into());
+    /// assert_eq!(attributes.priority, UPriority::UPRIORITY_CS2.into());
+    /// assert_eq!(attributes.sink, Some(origin).into());
+    /// ```
     pub fn notification(priority: UPriority, sink: UUri) -> UAttributesBuilder {
         UAttributesBuilder {
-            id: UUIDv8Builder::new().build(),
+            id: UUIDBuilder::new().build(),
             message_type: UMessageType::UMESSAGE_TYPE_PUBLISH,
             priority,
             ttl: None,
@@ -88,7 +95,7 @@ impl UAttributesBuilder {
     /// The builder initialized with the given values.
     pub fn request(priority: UPriority, sink: UUri, ttl: u32) -> UAttributesBuilder {
         UAttributesBuilder {
-            id: UUIDv8Builder::new().build(),
+            id: UUIDBuilder::new().build(),
             message_type: UMessageType::UMESSAGE_TYPE_REQUEST,
             priority,
             ttl: Some(i32::try_from(ttl).unwrap_or(i32::MAX)),
@@ -113,7 +120,7 @@ impl UAttributesBuilder {
     /// The builder initialized with the given values.
     pub fn response(priority: UPriority, sink: UUri, reqid: UUID) -> UAttributesBuilder {
         UAttributesBuilder {
-            id: UUIDv8Builder::new().build(),
+            id: UUIDBuilder::new().build(),
             message_type: UMessageType::UMESSAGE_TYPE_RESPONSE,
             priority,
             ttl: None,

--- a/src/transport/validator/uattributesvalidator.rs
+++ b/src/transport/validator/uattributesvalidator.rs
@@ -497,7 +497,7 @@ mod tests {
     use crate::transport::builder::UAttributesBuilder;
     use crate::uprotocol::{UAuthority, UEntity, UPriority, UUri, UUID};
     use crate::uri::builder::resourcebuilder::UResourceBuilder;
-    use crate::uuid::builder::UUIDv8Builder;
+    use crate::uuid::builder::UUIDBuilder;
 
     #[test]
     fn test_fetching_validator_for_valid_types() {
@@ -548,7 +548,7 @@ mod tests {
             .with_sink(build_sink())
             .with_permission_level(2)
             .with_commstatus(3)
-            .with_reqid(UUIDv8Builder::new().build())
+            .with_reqid(UUIDBuilder::new().build())
             .build();
         let validator = Validators::Publish.validator();
         let status = validator.validate(&attributes);
@@ -560,7 +560,7 @@ mod tests {
         let attributes = UAttributesBuilder::response(
             UPriority::UPRIORITY_CS0,
             build_sink(),
-            UUIDv8Builder::new().build(),
+            UUIDBuilder::new().build(),
         )
         .build();
 
@@ -655,7 +655,7 @@ mod tests {
         let attributes = UAttributesBuilder::request(UPriority::UPRIORITY_CS4, build_sink(), 1000)
             .with_permission_level(2)
             .with_commstatus(3)
-            .with_reqid(UUIDv8Builder::new().build())
+            .with_reqid(UUIDBuilder::new().build())
             .build();
 
         let validator = Validators::Request.validator();
@@ -668,7 +668,7 @@ mod tests {
         let attributes = UAttributesBuilder::response(
             UPriority::UPRIORITY_CS4,
             build_sink(),
-            UUIDv8Builder::new().build(),
+            UUIDBuilder::new().build(),
         )
         .with_ttl(1000)
         .build();
@@ -743,7 +743,7 @@ mod tests {
         let attributes = UAttributesBuilder::response(
             UPriority::UPRIORITY_CS4,
             build_sink(),
-            UUIDv8Builder::new().build(),
+            UUIDBuilder::new().build(),
         )
         .build();
 
@@ -757,7 +757,7 @@ mod tests {
         let attributes = UAttributesBuilder::response(
             UPriority::UPRIORITY_CS4,
             build_sink(),
-            UUIDv8Builder::new().build(),
+            UUIDBuilder::new().build(),
         )
         .with_permission_level(2)
         .with_commstatus(3)
@@ -783,7 +783,7 @@ mod tests {
         let attributes = UAttributesBuilder::response(
             UPriority::UPRIORITY_CS4,
             build_sink(),
-            UUIDv8Builder::new().build(),
+            UUIDBuilder::new().build(),
         )
         .with_ttl(0)
         .build();
@@ -799,7 +799,7 @@ mod tests {
         let attributes = UAttributesBuilder::response(
             UPriority::UPRIORITY_CS4,
             build_sink(),
-            UUIDv8Builder::new().build(),
+            UUIDBuilder::new().build(),
         )
         .with_permission_level(0)
         .build();
@@ -815,7 +815,7 @@ mod tests {
         let attributes = UAttributesBuilder::response(
             UPriority::UPRIORITY_CS4,
             build_sink(),
-            UUIDv8Builder::new().build(),
+            UUIDBuilder::new().build(),
         )
         .with_commstatus(-42)
         .build();
@@ -851,7 +851,7 @@ mod tests {
         let attributes = UAttributesBuilder::response(
             UPriority::UPRIORITY_CS4,
             build_sink(),
-            UUIDv8Builder::new().build(),
+            UUIDBuilder::new().build(),
         )
         .with_reqid(invalid_uuid)
         .build();

--- a/src/uuid/builder/uuidbuilder.rs
+++ b/src/uuid/builder/uuidbuilder.rs
@@ -28,18 +28,18 @@ const MAX_TIMESTAMP_MASK: u64 = 0xffff << MAX_TIMESTAMP_BITS;
 ///
 /// The structure of the UUIDs created by this factory is defined in the
 /// [uProtocol specification](https://github.com/eclipse-uprotocol/up-spec/blob/main/basics/uuid.adoc).
-pub struct UUIDv8Builder {
+pub struct UUIDBuilder {
     msb: AtomicU64,
     lsb: u64,
 }
 
-impl Default for UUIDv8Builder {
+impl Default for UUIDBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl UUIDv8Builder {
+impl UUIDBuilder {
     /// Creates a new builder for creating uProtocol UUIDs.
     ///
     /// The same bulder instance can be used to create one or more UUIDs
@@ -48,9 +48,9 @@ impl UUIDv8Builder {
     /// # Examples
     ///
     /// ```rust
-    /// use up_rust::uuid::builder::UUIDv8Builder;
+    /// use up_rust::uuid::builder::UUIDBuilder;
     ///
-    /// let builder = UUIDv8Builder::new();
+    /// let builder = UUIDBuilder::new();
     /// let uuid1 = builder.build();
     /// assert!(uuid1.is_uprotocol_uuid());
     /// let uuid2 = builder.build();
@@ -58,7 +58,7 @@ impl UUIDv8Builder {
     /// assert_ne!(uuid1, uuid2);
     /// ```
     pub fn new() -> Self {
-        UUIDv8Builder {
+        UUIDBuilder {
             msb: AtomicU64::new(0),
             // set variant to RFC4122
             lsb: rand::thread_rng().gen::<u64>() & BITMASK_CLEAR_VARIANT
@@ -77,9 +77,9 @@ impl UUIDv8Builder {
     /// # Examples
     ///
     /// ```rust
-    /// use up_rust::uuid::builder::UUIDv8Builder;
+    /// use up_rust::uuid::builder::UUIDBuilder;
     ///
-    /// let uuid = UUIDv8Builder::new().build();
+    /// let uuid = UUIDBuilder::new().build();
     /// assert!(uuid.is_uprotocol_uuid());
     /// assert!(uuid.get_time().is_some());
     /// ```
@@ -140,7 +140,7 @@ mod tests {
     #[test]
     fn test_build_with_instant_creates_uprotocol_uuid() {
         let instant = 0x18C684468F8_u64; // Thu, 14 Dec 2023 12:19:23 GMT
-        let uuid = UUIDv8Builder::new().build_with_instant(instant);
+        let uuid = UUIDBuilder::new().build_with_instant(instant);
         assert!(uuid.is_uprotocol_uuid());
         assert_eq!(uuid.get_time().unwrap(), instant);
 
@@ -153,7 +153,7 @@ mod tests {
     #[test]
     fn test_uuid_for_subsequent_generation() {
         let instant = 0x18C684468F8_u64; // Thu, 14 Dec 2023 12:19:23 GMT
-        let builder = UUIDv8Builder::new();
+        let builder = UUIDBuilder::new();
 
         let uuid_for_instant = builder.build_with_instant(instant);
         assert!(uuid_for_instant.is_uprotocol_uuid());
@@ -172,7 +172,7 @@ mod tests {
 
     #[test]
     fn test_uuid_for_constant_random() {
-        let factory = UUIDv8Builder::new();
+        let factory = UUIDBuilder::new();
         let uuid1 = factory.build();
         let uuid2 = factory.build();
         assert_eq!(uuid1.lsb, uuid2.lsb);
@@ -187,7 +187,7 @@ mod tests {
         // add 1 millisecond to the maximum duration, to overflow
         let overflowed_48_bit_unix_ts_ms = max_48_bit_unix_ts_ms + 1;
 
-        let builder = UUIDv8Builder::new();
+        let builder = UUIDBuilder::new();
         let _uprotocol_uuid_past_max_unix_ts_ms =
             builder.build_with_instant(overflowed_48_bit_unix_ts_ms);
     }


### PR DESCRIPTION
Since we are only using v8 UUIDs in uProtocol, there is no more
reason to add the version to the name of the builder.