### PR TITLE
Add job for building documentation

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -58,7 +58,8 @@ jobs:
           cargo --version
       - name: Run tests and report code coverage
         run: |
-          cargo tarpaulin -o xml -o lcov -o html
+          # enable nightly features so that we can also include Doctests
+          RUSTC_BOOTSTRAP=1 cargo tarpaulin -o xml -o lcov -o html --doc --tests
 
       - name: Upload coverage report (xml)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -83,3 +83,13 @@ jobs:
       #   with:
       #     name: Code coverage report
       #     path: cobertura.xml
+
+  build-docs:
+    name: Build documentation
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create Documentation
+        working-directory: ${{github.workspace}}
+        run: RUSTDOCFLAGS=-Dwarnings cargo doc -p up-rust --no-deps

--- a/src/uuid/builder/uuidbuilder.rs
+++ b/src/uuid/builder/uuidbuilder.rs
@@ -43,7 +43,7 @@ impl UUIDv8Builder {
     /// Creates a new builder for creating uProtocol UUIDs.
     ///
     /// The same bulder instance can be used to create one or more UUIDs
-    /// by means of invoking [`UUIDBuilder::build`].
+    /// by means of invoking [`UUIDv8Builder::build`].
     ///
     /// # Examples
     ///


### PR DESCRIPTION
A job has been added to the workflow which fails the workflow run
if documentation for the up-rust package cannot be built.