### PR TITLE
Fix/improve UMessageBuilder and UAttributesValidator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ utwin = []
 [dependencies]
 async-trait = { version = "0.1" }
 bytes = { version = "1.5" }
-chrono = { version = "0.4" }
+chrono = { version = "0.4.32" }
 cloudevents-sdk = { version = "0.7", optional = true }
 mediatype = "0.19"
 protobuf = { version = "3.3" }

--- a/src/umessage/umessagebuilder.rs
+++ b/src/umessage/umessagebuilder.rs
@@ -17,7 +17,7 @@ use protobuf::Message;
 use crate::uattributes::UAttributesError;
 use crate::{
     Data, PublishValidator, RequestValidator, ResponseValidator, UAttributes, UAttributesValidator,
-    UMessage, UMessageType, UPayload, UPayloadFormat, UPriority, UUIDBuilder, UUri, UUID,
+    UMessage, UMessageType, UPayload, UPayloadFormat, UPriority, UUri, UUID,
 };
 
 #[derive(Debug)]
@@ -58,27 +58,29 @@ impl From<protobuf::Error> for UMessageBuilderError {
 ///
 /// Messages are being used by a uEntity to inform other entities about the occurrence of events
 /// and/or to invoke service operations provided by other entities.
-pub struct UMessageBuilder<'a> {
+pub struct UMessageBuilder {
     validator: Box<dyn UAttributesValidator>,
     message_type: UMessageType,
-    source: Option<&'a UUri>,
-    sink: Option<&'a UUri>,
+    message_id: Option<UUID>,
+    source: Option<UUri>,
+    sink: Option<UUri>,
     priority: UPriority,
     ttl: Option<i32>,
-    token: Option<&'a String>,
+    token: Option<String>,
     permission_level: Option<i32>,
     comm_status: Option<i32>,
-    request_id: Option<&'a UUID>,
+    request_id: Option<UUID>,
     payload: Option<Bytes>,
     payload_format: UPayloadFormat,
 }
 
-impl<'a> Default for UMessageBuilder<'a> {
+impl Default for UMessageBuilder {
     fn default() -> Self {
         UMessageBuilder {
             validator: Box::new(PublishValidator),
             comm_status: None,
             message_type: UMessageType::UMESSAGE_TYPE_UNSPECIFIED,
+            message_id: None,
             payload: None,
             payload_format: UPayloadFormat::UPAYLOAD_FORMAT_UNSPECIFIED,
             permission_level: None,
@@ -92,8 +94,8 @@ impl<'a> Default for UMessageBuilder<'a> {
     }
 }
 
-impl<'a> UMessageBuilder<'a> {
-    /// Gets a builder for creating a *publish* message.
+impl UMessageBuilder {
+    /// Gets a builder for creating *publish* messages.
     ///
     /// A publish message is used to notify all interested consumers of an event that has occurred.
     /// Consumers usually indicate their interest by *subscribing* to a particular topic.
@@ -110,15 +112,16 @@ impl<'a> UMessageBuilder<'a> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let uuid_builder = UUIDBuilder::new();
     /// let topic = UUri::try_from("my-vehicle/cabin/1/doors.driver_side#status")?;
-    /// let message = UMessageBuilder::publish(&topic)
-    ///                    .build_with_payload(&uuid_builder, "closed".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
+    /// let message = UMessageBuilder::publish(topic.clone())
+    ///                    .with_message_id(uuid_builder.build())
+    ///                    .build_with_payload("closed".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
     /// assert_eq!(message.attributes.type_, UMessageType::UMESSAGE_TYPE_PUBLISH.into());
     /// assert_eq!(message.attributes.priority, UPriority::UPRIORITY_CS1.into());
     /// assert_eq!(message.attributes.source, Some(topic).into());
     /// # Ok(())
     /// # }
     /// ```
-    pub fn publish(topic: &'a UUri) -> UMessageBuilder<'a> {
+    pub fn publish(topic: UUri) -> UMessageBuilder {
         UMessageBuilder {
             validator: Box::new(PublishValidator),
             message_type: UMessageType::UMESSAGE_TYPE_PUBLISH,
@@ -127,12 +130,13 @@ impl<'a> UMessageBuilder<'a> {
         }
     }
 
-    /// Gets a builder for creating a *notification* message.
+    /// Gets a builder for creating *notification* messages.
     ///
     /// A notification is used to inform a specific consumer about an event that has occurred.
     ///
     /// # Arguments
     ///
+    /// * `origin` - The component that the notification originates from.
     /// * `destination` - The URI identifying the destination to send the notification to.
     ///
     /// # Examples
@@ -142,25 +146,29 @@ impl<'a> UMessageBuilder<'a> {
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let uuid_builder = UUIDBuilder::new();
+    /// let origin = UUri::try_from("my-vehicle/cabin/1/dashcam#event")?;
     /// let destination = UUri::try_from("my-cloud/companion/1/alarm")?;
-    /// let message = UMessageBuilder::notification(&destination)
-    ///                    .build_with_payload(&uuid_builder, "unexpected movement".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
+    /// let message = UMessageBuilder::notification(origin.clone(), destination.clone())
+    ///                    .with_message_id(uuid_builder.build())
+    ///                    .build_with_payload("unexpected movement".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
     /// assert_eq!(message.attributes.type_, UMessageType::UMESSAGE_TYPE_PUBLISH.into());
     /// assert_eq!(message.attributes.priority, UPriority::UPRIORITY_CS1.into());
+    /// assert_eq!(message.attributes.source, Some(origin).into());
     /// assert_eq!(message.attributes.sink, Some(destination).into());
     /// # Ok(())
     /// # }
     /// ```
-    pub fn notification(destination: &'a UUri) -> UMessageBuilder<'a> {
+    pub fn notification(origin: UUri, destination: UUri) -> UMessageBuilder {
         UMessageBuilder {
             validator: Box::new(PublishValidator),
             message_type: UMessageType::UMESSAGE_TYPE_PUBLISH,
+            source: Some(origin),
             sink: Some(destination),
             ..Default::default()
         }
     }
 
-    /// Gets a builder for creating an RPC *request* message.
+    /// Gets a builder for creating RPC *request* messages.
     ///
     /// A request message is used to invoke a service's method with some input data, expecting
     /// the service to reply with a response message which is correlated by means of the `request_id`.
@@ -169,7 +177,6 @@ impl<'a> UMessageBuilder<'a> {
     ///
     /// * `method_to_invoke` - The URI identifying the method to invoke.
     /// * `reply_to_address` - The URI that the sender of the request expects the response message at.
-    /// * `request_id` - The identifier that the response needs to contain to be correlated to this request.
     /// * `ttl` - The number of milliseconds after which the request should no longer be processed
     ///           by the target service. The value is capped at [`i32::MAX`].
     ///
@@ -182,36 +189,29 @@ impl<'a> UMessageBuilder<'a> {
     /// let uuid_builder = UUIDBuilder::new();
     /// let method_to_invoke = UUri::try_from("my-vehicle/cabin/1/rpc.doors")?;
     /// let reply_to_address = UUri::try_from("my-cloud/dashboard/1/rpc.response")?;
-    /// let request_id = uuid_builder.build();
-    /// let message = UMessageBuilder::request(&method_to_invoke, &reply_to_address, &request_id, 5000)
-    ///                     .build_with_payload(&uuid_builder, "lock".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
+    /// let message = UMessageBuilder::request(method_to_invoke.clone(), reply_to_address.clone(), 5000)
+    ///                    .with_message_id(uuid_builder.build())
+    ///                    .build_with_payload("lock".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
     /// assert_eq!(message.attributes.type_, UMessageType::UMESSAGE_TYPE_REQUEST.into());
     /// assert_eq!(message.attributes.priority, UPriority::UPRIORITY_CS1.into());
     /// assert_eq!(message.attributes.source, Some(reply_to_address).into());
     /// assert_eq!(message.attributes.sink, Some(method_to_invoke).into());
-    /// assert_eq!(message.attributes.reqid, Some(request_id).into());
     /// assert_eq!(message.attributes.ttl, Some(5000));
     /// # Ok(())
     /// # }
     /// ```
-    pub fn request(
-        method_to_invoke: &'a UUri,
-        reply_to_address: &'a UUri,
-        request_id: &'a UUID,
-        ttl: u32,
-    ) -> UMessageBuilder<'a> {
+    pub fn request(method_to_invoke: UUri, reply_to_address: UUri, ttl: u32) -> UMessageBuilder {
         UMessageBuilder {
             validator: Box::new(RequestValidator),
             message_type: UMessageType::UMESSAGE_TYPE_REQUEST,
             source: Some(reply_to_address),
             sink: Some(method_to_invoke),
-            request_id: Some(request_id),
             ttl: Some(i32::try_from(ttl).unwrap_or(i32::MAX)),
             ..Default::default()
         }
     }
 
-    /// Gets a builder for creating an RPC *response* message.
+    /// Gets a builder for creating RPC *response* messages.
     ///
     /// A response message is used to send the outcome of processing a request message
     /// to the original sender of the request message.
@@ -233,7 +233,9 @@ impl<'a> UMessageBuilder<'a> {
     /// let invoked_method = UUri::try_from("my-vehicle/cabin/1/rpc.doors")?;
     /// let reply_to_address = UUri::try_from("my-cloud/dashboard/1/rpc.response")?;
     /// let request_id = uuid_builder.build();
-    /// let message = UMessageBuilder::response(&reply_to_address, &request_id, &invoked_method).build(&uuid_builder)?;
+    /// let message = UMessageBuilder::response(reply_to_address.clone(), request_id.clone(), invoked_method.clone())
+    ///                    .with_message_id(uuid_builder.build())
+    ///                    .build()?;
     /// assert_eq!(message.attributes.type_, UMessageType::UMESSAGE_TYPE_RESPONSE.into());
     /// assert_eq!(message.attributes.priority, UPriority::UPRIORITY_CS1.into());
     /// assert_eq!(message.attributes.source, Some(invoked_method).into());
@@ -243,10 +245,10 @@ impl<'a> UMessageBuilder<'a> {
     /// # }
     /// ```
     pub fn response(
-        reply_to_address: &'a UUri,
-        request_id: &'a UUID,
-        invoked_method: &'a UUri,
-    ) -> UMessageBuilder<'a> {
+        reply_to_address: UUri,
+        request_id: UUID,
+        invoked_method: UUri,
+    ) -> UMessageBuilder {
         UMessageBuilder {
             validator: Box::new(ResponseValidator),
             message_type: UMessageType::UMESSAGE_TYPE_RESPONSE,
@@ -257,7 +259,7 @@ impl<'a> UMessageBuilder<'a> {
         }
     }
 
-    /// Gets a builder for creating an RPC *response* message in reply to a *request*.
+    /// Gets a builder for creating RPC *response* messages in reply to a *request*.
     ///
     /// A response message is used to send the outcome of processing a request message
     /// to the original sender of the request message.
@@ -276,29 +278,85 @@ impl<'a> UMessageBuilder<'a> {
     /// let uuid_builder = UUIDBuilder::new();
     /// let method_to_invoke = UUri::try_from("my-vehicle/cabin/1/rpc.doors")?;
     /// let reply_to_address = UUri::try_from("my-cloud/dashboard/1/rpc.response")?;
-    /// let request_id = uuid_builder.build();
-    /// let request_message = UMessageBuilder::request(&method_to_invoke, &reply_to_address, &request_id, 5000)
-    ///                     .build_with_payload(&uuid_builder, "lock".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
+    /// let request_message_id = uuid_builder.build();
+    /// let request_message = UMessageBuilder::request(method_to_invoke.clone(), reply_to_address.clone(), 5000)
+    ///                           .with_message_id(request_message_id.clone())
+    ///                           .build_with_payload("lock".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
     ///
     /// let response_message = UMessageBuilder::response_for_request(&request_message.attributes)
-    ///                           .build(&uuid_builder)?;
+    ///                           .with_message_id(uuid_builder.build())
+    ///                           .build()?;
     /// assert_eq!(response_message.attributes.type_, UMessageType::UMESSAGE_TYPE_RESPONSE.into());
     /// assert_eq!(response_message.attributes.priority, UPriority::UPRIORITY_CS1.into());
     /// assert_eq!(response_message.attributes.source, Some(method_to_invoke).into());
     /// assert_eq!(response_message.attributes.sink, Some(reply_to_address).into());
-    /// assert_eq!(response_message.attributes.reqid, Some(request_id).into());
+    /// assert_eq!(response_message.attributes.reqid, Some(request_message_id).into());
     /// # Ok(())
     /// # }
     /// ```
-    pub fn response_for_request(request_attributes: &'a UAttributes) -> UMessageBuilder<'a> {
+    pub fn response_for_request(request_attributes: &UAttributes) -> UMessageBuilder {
         UMessageBuilder {
             validator: Box::new(ResponseValidator),
             message_type: UMessageType::UMESSAGE_TYPE_RESPONSE,
-            source: request_attributes.sink.as_ref(),
-            sink: request_attributes.source.as_ref(),
-            request_id: request_attributes.reqid.as_ref(),
+            source: request_attributes.sink.as_ref().cloned(),
+            sink: request_attributes.source.as_ref().cloned(),
+            request_id: request_attributes.id.as_ref().cloned(),
             ..Default::default()
         }
+    }
+
+    /// Sets the message's identifier.
+    ///
+    /// Every message must have an identifier and any of the build functions will return an error if no
+    /// identifier has been set.
+    ///
+    /// This function is particularly helpful in order to re-use a builder for creating multiple
+    /// messages consecutively based on the same attributes, differing in payload only as illustrated
+    /// in the examples.
+    ///
+    /// # Arguments
+    ///
+    /// * `message_id` - The identifier to use.
+    ///
+    /// # Returns
+    ///
+    /// The builder.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given UUID is not a [valid uProtocol UUID](`UUID::is_uprotocol_uuid`).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use up_rust::{UMessageBuilder, UMessageType, UPayloadFormat, UPriority, UUIDBuilder, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let uuid_builder = UUIDBuilder::new();
+    /// let topic = UUri::try_from("my-vehicle/cabin/1/doors.driver_side#status")?;
+    /// let mut builder = UMessageBuilder::publish(topic);
+    /// builder.with_priority(UPriority::UPRIORITY_CS2);
+    /// let message_one = builder
+    ///                     .with_message_id(uuid_builder.build())
+    ///                     .build_with_payload("closed".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
+    /// let message_two = builder
+    ///                     // use new message ID but retain all other attributes
+    ///                     .with_message_id(uuid_builder.build())
+    ///                     .build_with_payload("open".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
+    /// assert_ne!(message_one.attributes.id, message_two.attributes.id);
+    /// assert_eq!(message_one.attributes.source, message_two.attributes.source);
+    /// assert_eq!(message_one.attributes.priority, UPriority::UPRIORITY_CS2.into());
+    /// assert_eq!(message_two.attributes.priority, UPriority::UPRIORITY_CS2.into());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_message_id(&mut self, message_id: UUID) -> &mut UMessageBuilder {
+        assert!(
+            message_id.is_uprotocol_uuid(),
+            "Message ID must be a valid uProtocol UUID"
+        );
+        self.message_id = Some(message_id);
+        self
     }
 
     /// Sets the message's priority.
@@ -323,14 +381,15 @@ impl<'a> UMessageBuilder<'a> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let uuid_builder = UUIDBuilder::new();
     /// let topic = UUri::try_from("my-vehicle/cabin/1/doors.driver_side#status")?;
-    /// let message = UMessageBuilder::publish(&topic)
-    ///                 .with_priority(UPriority::UPRIORITY_CS5)
-    ///                 .build_with_payload(&uuid_builder, "closed".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
+    /// let message = UMessageBuilder::publish(topic)
+    ///                   .with_message_id(uuid_builder.build())
+    ///                   .with_priority(UPriority::UPRIORITY_CS5)
+    ///                   .build_with_payload("closed".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
     /// assert_eq!(message.attributes.priority, UPriority::UPRIORITY_CS5.into());
     /// # Ok(())
     /// # }
     /// ```
-    pub fn with_priority(&'a mut self, priority: UPriority) -> &'a mut UMessageBuilder {
+    pub fn with_priority(&mut self, priority: UPriority) -> &mut UMessageBuilder {
         self.priority = priority;
         self
     }
@@ -354,15 +413,15 @@ impl<'a> UMessageBuilder<'a> {
     /// let uuid_builder = UUIDBuilder::new();
     /// let invoked_method = UUri::try_from("my-vehicle/cabin/1/rpc.doors")?;
     /// let reply_to_address = UUri::try_from("my-cloud/dashboard/1/rpc.response")?;
-    /// let request_id = uuid_builder.build();
-    /// let message = UMessageBuilder::response(&reply_to_address, &request_id, &invoked_method)
+    /// let message = UMessageBuilder::response(reply_to_address, uuid_builder.build(), invoked_method)
+    ///                     .with_message_id(uuid_builder.build())
     ///                     .with_ttl(2000)
-    ///                     .build(&uuid_builder)?;
+    ///                     .build()?;
     /// assert_eq!(message.attributes.ttl, Some(2000));
     /// # Ok(())
     /// # }
     /// ```
-    pub fn with_ttl(&'a mut self, ttl: u32) -> &'a mut UMessageBuilder {
+    pub fn with_ttl(&mut self, ttl: u32) -> &mut UMessageBuilder {
         self.ttl = Some(i32::try_from(ttl).unwrap_or(i32::MAX));
         self
     }
@@ -377,6 +436,10 @@ impl<'a> UMessageBuilder<'a> {
     ///
     /// The builder.
     ///
+    /// # Panics
+    ///
+    /// * if the message is not an RPC request message
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -387,14 +450,16 @@ impl<'a> UMessageBuilder<'a> {
     /// let method_to_invoke = UUri::try_from("my-vehicle/cabin/1/rpc.doors")?;
     /// let reply_to_address = UUri::try_from("my-cloud/dashboard/1/rpc.response")?;
     /// let token = String::from("this-is-my-token");
-    /// let message = UMessageBuilder::request(&method_to_invoke, &reply_to_address, &uuid_builder.build(), 5000)
-    ///                     .with_token(&token)
-    ///                     .build_with_payload(&uuid_builder, "lock".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
+    /// let message = UMessageBuilder::request(method_to_invoke, reply_to_address, 5000)
+    ///                     .with_message_id(uuid_builder.build())
+    ///                     .with_token(token.clone())
+    ///                     .build_with_payload("lock".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
     /// assert_eq!(message.attributes.token, Some(token));
     /// # Ok(())
     /// # }
     /// ```
-    pub fn with_token(&'a mut self, token: &'a String) -> &'a mut UMessageBuilder {
+    pub fn with_token(&mut self, token: String) -> &mut UMessageBuilder {
+        assert!(self.message_type == UMessageType::UMESSAGE_TYPE_REQUEST);
         self.token = Some(token);
         self
     }
@@ -411,7 +476,8 @@ impl<'a> UMessageBuilder<'a> {
     ///
     /// # Panics
     ///
-    /// if the given level is 0 or greater than [`i32::MAX`].
+    /// * if the given level is greater than [`i32::MAX`]
+    /// * if the message is not an RPC request message
     ///
     /// # Examples
     ///
@@ -422,16 +488,19 @@ impl<'a> UMessageBuilder<'a> {
     /// let uuid_builder = UUIDBuilder::new();
     /// let method_to_invoke = UUri::try_from("my-vehicle/cabin/1/rpc.doors")?;
     /// let reply_to_address = UUri::try_from("my-cloud/dashboard/1/rpc.response")?;
-    /// let message = UMessageBuilder::request(&method_to_invoke, &reply_to_address, &uuid_builder.build(), 5000)
+    /// let message = UMessageBuilder::request(method_to_invoke, reply_to_address, 5000)
+    ///                     .with_message_id(uuid_builder.build())
     ///                     .with_permission_level(12)
-    ///                     .build_with_payload(&uuid_builder, "lock".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
+    ///                     .build_with_payload("lock".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
     /// assert_eq!(message.attributes.permission_level, Some(12));
     /// # Ok(())
     /// # }
     /// ```
-    pub fn with_permission_level(&'a mut self, level: u32) -> &'a mut UMessageBuilder {
-        assert!(level > 0, "permission level must be a positive integer");
+    pub fn with_permission_level(&mut self, level: u32) -> &mut UMessageBuilder {
+        assert!(self.message_type == UMessageType::UMESSAGE_TYPE_REQUEST);
         self.permission_level =
+            // this will not be needed anymore once up-core-api 1.5.7 is released and
+            // permission_level is defined as a uint32
             Some(i32::try_from(level).expect("permission level must not exceed i32::MAX"));
         self
     }
@@ -446,6 +515,10 @@ impl<'a> UMessageBuilder<'a> {
     ///
     /// The builder.
     ///
+    /// # Panics
+    ///
+    /// * if the message is not an RPC response message
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -456,25 +529,22 @@ impl<'a> UMessageBuilder<'a> {
     /// let uuid_builder = UUIDBuilder::new();
     /// let invoked_method = UUri::try_from("my-vehicle/cabin/1/rpc.doors")?;
     /// let reply_to_address = UUri::try_from("my-cloud/dashboard/1/rpc.response")?;
-    /// let request_id = uuid_builder.build();
     /// let status = UCode::OK.value();
-    /// let message = UMessageBuilder::response(&reply_to_address, &request_id, &invoked_method)
+    /// let message = UMessageBuilder::response(reply_to_address, uuid_builder.build(), invoked_method)
+    ///                     .with_message_id(uuid_builder.build())
     ///                     .with_comm_status(status)
-    ///                     .build(&uuid_builder)?;
+    ///                     .build()?;
     /// assert_eq!(message.attributes.commstatus, Some(status));
     /// # Ok(())
     /// # }
     /// ```
-    pub fn with_comm_status(&'a mut self, comm_status: i32) -> &'a mut UMessageBuilder {
+    pub fn with_comm_status(&mut self, comm_status: i32) -> &mut UMessageBuilder {
+        assert!(self.message_type == UMessageType::UMESSAGE_TYPE_RESPONSE);
         self.comm_status = Some(comm_status);
         self
     }
 
     /// Creates the message based on the builder's state.
-    ///
-    /// # Arguments
-    ///
-    /// * `uuid_builder` - A (shared) builder for creating the message ID.
     ///
     /// # Returns
     ///
@@ -495,25 +565,42 @@ impl<'a> UMessageBuilder<'a> {
     /// # let lsb = uuid_builder.build().lsb;
     /// let invoked_method = UUri::try_from("my-vehicle/cabin/1/rpc.doors")?;
     /// let reply_to_address = UUri::try_from("my-cloud/dashboard/1/rpc.response")?;
-    /// let request_id = uuid_builder.build();
-    /// let message = UMessageBuilder::response(&reply_to_address, &request_id, &invoked_method).build(&uuid_builder)?;
-    /// assert!(message.attributes.id.is_some());
+    /// let message_id = uuid_builder.build();
+    /// let message = UMessageBuilder::response(reply_to_address, uuid_builder.build(), invoked_method)
+    ///                     .with_message_id(message_id.clone())
+    ///                     .build()?;
+    /// assert_eq!(message.attributes.id, Some(message_id).into());
     /// # assert_eq!(message.attributes.id.clone().unwrap().lsb, lsb);
     /// # Ok(())
     /// # }
     /// ```
-    pub fn build(&self, uuid_builder: &UUIDBuilder) -> Result<UMessage, UMessageBuilderError> {
+    ///
+    /// ## Missing Message ID
+    ///
+    /// ```rust
+    /// use up_rust::{UAttributes, UAttributesValidators, UMessageBuilder, UMessageBuilderError, UMessageType, UPriority, UUIDBuilder, UUri};
+    ///
+    /// let uuid_builder = UUIDBuilder::new();
+    /// let invoked_method = UUri::try_from("my-vehicle/cabin/1/rpc.doors").unwrap();
+    /// let reply_to_address = UUri::try_from("my-cloud/dashboard/1/rpc.response").unwrap();
+    /// let result = UMessageBuilder::response(reply_to_address, uuid_builder.build(), invoked_method)
+    ///                     .build();
+    /// assert!(result.is_err());
+    /// assert!(matches!(result.unwrap_err(), UMessageBuilderError::AttributesValidationError(msg)));
+    /// ```
+
+    pub fn build(&self) -> Result<UMessage, UMessageBuilderError> {
         let attributes = UAttributes {
-            id: Some(uuid_builder.build()).into(),
+            id: self.message_id.clone().into(),
             type_: self.message_type.into(),
-            source: self.source.cloned().into(),
-            sink: self.sink.cloned().into(),
+            source: self.source.clone().into(),
+            sink: self.sink.clone().into(),
             priority: self.priority.into(),
             ttl: self.ttl,
-            token: self.token.cloned(),
+            token: self.token.clone(),
             permission_level: self.permission_level,
             commstatus: self.comm_status,
-            reqid: self.request_id.cloned().into(),
+            reqid: self.request_id.clone().into(),
             ..Default::default()
         };
         self.validator
@@ -541,7 +628,6 @@ impl<'a> UMessageBuilder<'a> {
     ///
     /// # Arguments
     ///
-    /// * `uuid_builder` - A (shared) builder for creating the message ID.
     /// * `payload` - The data to set as payload.
     /// * `format` - The payload format.
     ///
@@ -560,30 +646,29 @@ impl<'a> UMessageBuilder<'a> {
     /// use up_rust::{UMessageBuilder, UMessageType, UPayloadFormat, UPriority, UUIDBuilder, UUri};
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let uuid_builder = UUIDBuilder::new();
     /// let topic = UUri::try_from("my-vehicle/cabin/1/doors.driver_side#status")?;
-    /// let message = UMessageBuilder::publish(&topic)
-    ///                 .build_with_payload(&uuid_builder, "locked".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
+    /// let message_id = UUIDBuilder::new().build();
+    /// let message = UMessageBuilder::publish(topic)
+    ///                    .with_message_id(message_id)
+    ///                    .build_with_payload("locked".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
     /// assert!(message.payload.is_some());
     /// # Ok(())
     /// # }
     /// ```
     pub fn build_with_payload(
-        &'a mut self,
-        uuid_builder: &UUIDBuilder,
+        &mut self,
         payload: Bytes,
         format: UPayloadFormat,
     ) -> Result<UMessage, UMessageBuilderError> {
         self.payload = Some(payload);
         self.payload_format = format;
-        self.build(uuid_builder)
+        self.build()
     }
 
     /// Creates the message based on the builder's state and some payload.
     ///
     /// # Arguments
     ///
-    /// * `uuid_builder` - A (shared) builder for creating the message ID.
     /// * `payload` - The data to set as payload.
     /// * `format` - The payload format.
     ///
@@ -608,16 +693,16 @@ impl<'a> UMessageBuilder<'a> {
     /// let invoked_method = UUri::try_from("my-vehicle/cabin/1/rpc.doors")?;
     /// let reply_to_address = UUri::try_from("my-cloud/dashboard/1/rpc.response")?;
     /// let request_id = uuid_builder.build();
-    /// let message = UMessageBuilder::response(&reply_to_address, &request_id, &invoked_method)
-    ///                 .with_comm_status(UCode::INVALID_ARGUMENT.value())
-    ///                 .build_with_protobuf_payload(&uuid_builder, &UStatus::fail("failed to parse request"))?;
+    /// let message = UMessageBuilder::response(reply_to_address, request_id, invoked_method)
+    ///                    .with_message_id(uuid_builder.build())
+    ///                    .with_comm_status(UCode::INVALID_ARGUMENT.value())
+    ///                    .build_with_protobuf_payload(&UStatus::fail("failed to parse request"))?;
     /// assert!(message.payload.is_some());
     /// # Ok(())
     /// # }
     /// ```
     pub fn build_with_protobuf_payload<T: Message>(
-        &'a mut self,
-        uuid_builder: &UUIDBuilder,
+        &mut self,
         payload: &T,
     ) -> Result<UMessage, UMessageBuilderError> {
         payload
@@ -625,7 +710,6 @@ impl<'a> UMessageBuilder<'a> {
             .map_err(UMessageBuilderError::from)
             .and_then(|serialized_payload| {
                 self.build_with_payload(
-                    uuid_builder,
                     serialized_payload.into(),
                     UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF,
                 )
@@ -635,6 +719,8 @@ impl<'a> UMessageBuilder<'a> {
 
 #[cfg(test)]
 mod tests {
+    use crate::UUIDBuilder;
+
     use super::*;
 
     use test_case::test_case;
@@ -643,50 +729,117 @@ mod tests {
     const REPLY_TO_ADDRESS: &str = "my-cloud/dashboard/1/rpc.response";
     const TOPIC: &str = "my-vehicle/cabin/1/doors.driver_side#status";
 
-    #[test_case(0; "for level 0")]
-    #[test_case(i32::MAX as u32 + 1; "for non i32 value")]
+    #[test]
     #[should_panic]
-    fn test_with_permission_level_panics(level: u32) {
-        let uuid_builder = UUIDBuilder::new();
+    fn test_with_message_id_panics_for_invalid_uuid() {
+        let invalid_message_id = UUID {
+            msb: 0x00000000000000ab_u64,
+            lsb: 0x0000000000018000_u64,
+            ..Default::default()
+        };
         let topic = UUri::try_from(TOPIC).expect("should have been able to create UUri");
-        let _ = UMessageBuilder::publish(&topic)
-            .with_permission_level(level)
-            .build_with_payload(
-                &uuid_builder,
-                "locked".into(),
-                UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
-            );
+        UMessageBuilder::publish(topic).with_message_id(invalid_message_id);
+    }
+
+    #[test_case(Some(5), None, None; "with permission level")]
+    #[test_case(None, Some(5), None; "with commstatus")]
+    #[test_case(None, None, Some(String::from("my-token")); "with token")]
+    #[should_panic]
+    fn test_publish_message_builder_panics(
+        perm_level: Option<u32>,
+        comm_status: Option<i32>,
+        token: Option<String>,
+    ) {
+        let topic = UUri::try_from(TOPIC).expect("should have been able to create UUri");
+        let mut builder = UMessageBuilder::publish(topic);
+        if let Some(level) = perm_level {
+            builder.with_permission_level(level);
+        } else if let Some(status_code) = comm_status {
+            builder.with_comm_status(status_code);
+        } else if let Some(t) = token {
+            builder.with_token(t);
+        }
+    }
+
+    #[test_case(Some(5), None; "with permission level")]
+    #[test_case(None, Some(String::from("my-token")); "with token")]
+    #[should_panic]
+    fn test_response_message_builder_panics(perm_level: Option<u32>, token: Option<String>) {
+        let uuid_builder = UUIDBuilder::new();
+        let request_id = uuid_builder.build();
+        let method_to_invoke = UUri::try_from(METHOD_TO_INVOKE)
+            .expect("should have been able to create destination UUri");
+        let reply_to_address = UUri::try_from(REPLY_TO_ADDRESS)
+            .expect("should have been able to create reply-to UUri");
+        let mut builder = UMessageBuilder::response(reply_to_address, request_id, method_to_invoke);
+
+        if let Some(level) = perm_level {
+            builder.with_permission_level(level);
+        } else if let Some(t) = token {
+            builder.with_token(t);
+        }
+    }
+
+    #[test_case(Some(5), None; "for comm status")]
+    #[test_case(None, Some(i32::MAX as u32 + 1); "for non i32 permission level value")]
+    #[should_panic]
+    fn test_request_message_builder_panics(comm_status: Option<i32>, perm_level: Option<u32>) {
+        let method_to_invoke = UUri::try_from(METHOD_TO_INVOKE)
+            .expect("should have been able to create destination UUri");
+        let reply_to_address = UUri::try_from(REPLY_TO_ADDRESS)
+            .expect("should have been able to create reply-to UUri");
+        let mut builder = UMessageBuilder::request(method_to_invoke, reply_to_address, 5000);
+
+        if let Some(status) = comm_status {
+            builder.with_comm_status(status);
+        } else if let Some(level) = perm_level {
+            builder.with_permission_level(level);
+        }
     }
 
     #[test]
     fn test_with_ttl_caps_value() {
         let uuid_builder = UUIDBuilder::new();
         let topic = UUri::try_from(TOPIC).expect("should have been able to create UUri");
-        let message = UMessageBuilder::publish(&topic)
+        let message = UMessageBuilder::publish(topic)
+            .with_message_id(uuid_builder.build())
             .with_ttl(i32::MAX as u32 + 10)
-            .build_with_payload(
-                &uuid_builder,
-                "locked".into(),
-                UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
-            )
+            .build_with_payload("locked".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)
             .expect("should have been able to create message");
         assert_eq!(message.attributes.ttl, Some(i32::MAX));
     }
 
     #[test]
-    fn test_build_retains_all_publish_attributes() {
+    fn test_build_supports_repeated_invocation() {
         let uuid_builder = UUIDBuilder::new();
         let topic = UUri::try_from(TOPIC).expect("should have been able to create UUri");
-        let message = UMessageBuilder::publish(&topic)
+        let mut builder = UMessageBuilder::publish(topic);
+        let message_one = builder
+            .with_message_id(uuid_builder.build())
+            .build_with_payload("locked".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)
+            .expect("should have been able to create message");
+        let message_two = builder
+            .with_message_id(uuid_builder.build())
+            .build_with_payload("unlocked".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)
+            .expect("should have been able to create message");
+        assert_eq!(message_one.attributes.type_, message_two.attributes.type_);
+        assert_ne!(message_one.attributes.id, message_two.attributes.id);
+        assert_eq!(message_one.attributes.source, message_two.attributes.source);
+        assert_ne!(message_one.payload, message_two.payload);
+    }
+
+    #[test]
+    fn test_build_retains_all_publish_attributes() {
+        let uuid_builder = UUIDBuilder::new();
+        let message_id = uuid_builder.build();
+        let topic = UUri::try_from(TOPIC).expect("should have been able to create UUri");
+        let message = UMessageBuilder::publish(topic.clone())
+            .with_message_id(message_id.clone())
             .with_priority(UPriority::UPRIORITY_CS2)
             .with_ttl(5000)
-            .build_with_payload(
-                &uuid_builder,
-                "locked".into(),
-                UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
-            )
+            .build_with_payload("locked".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)
             .expect("should have been able to create message");
-        assert!(message.attributes.id.is_some());
+        assert_eq!(message.attributes.id, Some(message_id).into());
         assert_eq!(message.attributes.priority, UPriority::UPRIORITY_CS2.into());
         assert_eq!(message.attributes.source, Some(topic).into());
         assert_eq!(message.attributes.ttl, Some(5000));
@@ -699,28 +852,24 @@ mod tests {
     #[test]
     fn test_build_retains_all_request_attributes() {
         let uuid_builder = UUIDBuilder::new();
-        let request_id = uuid_builder.build();
+        let message_id = uuid_builder.build();
         let token = String::from("token");
         let method_to_invoke = UUri::try_from(METHOD_TO_INVOKE)
             .expect("should have been able to create destination UUri");
         let reply_to_address = UUri::try_from(REPLY_TO_ADDRESS)
             .expect("should have been able to create reply-to UUri");
         let message =
-            UMessageBuilder::request(&method_to_invoke, &reply_to_address, &request_id, 5000)
+            UMessageBuilder::request(method_to_invoke.clone(), reply_to_address.clone(), 5000)
+                .with_message_id(message_id.clone())
                 .with_permission_level(5)
                 .with_priority(UPriority::UPRIORITY_CS4)
-                .with_token(&token)
-                .build_with_payload(
-                    &uuid_builder,
-                    "unlock".into(),
-                    UPayloadFormat::UPAYLOAD_FORMAT_TEXT,
-                )
+                .with_token(token.clone())
+                .build_with_payload("unlock".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)
                 .expect("should have been able to create message");
 
-        assert!(message.attributes.id.is_some());
+        assert_eq!(message.attributes.id, Some(message_id).into());
         assert_eq!(message.attributes.permission_level, Some(5));
         assert_eq!(message.attributes.priority, UPriority::UPRIORITY_CS4.into());
-        assert_eq!(message.attributes.reqid, Some(request_id).into());
         assert_eq!(message.attributes.sink, Some(method_to_invoke).into());
         assert_eq!(message.attributes.source, Some(reply_to_address).into());
         assert_eq!(message.attributes.token, Some(token));
@@ -734,25 +883,28 @@ mod tests {
     #[test]
     fn test_builder_copies_request_attributes() {
         let uuid_builder = UUIDBuilder::new();
-        let request_id = uuid_builder.build();
+        let request_message_id = uuid_builder.build();
+        let response_message_id = uuid_builder.build();
         let method_to_invoke = UUri::try_from(METHOD_TO_INVOKE)
             .expect("should have been able to create destination UUri");
         let reply_to_address = UUri::try_from(REPLY_TO_ADDRESS)
             .expect("should have been able to create reply-to UUri");
         let request_message =
-            UMessageBuilder::request(&method_to_invoke, &reply_to_address, &request_id, 5000)
-                .build(&uuid_builder)
+            UMessageBuilder::request(method_to_invoke.clone(), reply_to_address.clone(), 5000)
+                .with_message_id(request_message_id.clone())
+                .build()
                 .expect("should have been able to create message");
         let message = UMessageBuilder::response_for_request(&request_message.attributes)
+            .with_message_id(response_message_id.clone())
             .with_comm_status(0)
             .with_priority(UPriority::UPRIORITY_CS4)
             .with_ttl(0)
-            .build(&uuid_builder)
+            .build()
             .expect("should have been able to create message");
-        assert!(message.attributes.id.is_some());
+        assert_eq!(message.attributes.id, Some(response_message_id).into());
         assert_eq!(message.attributes.commstatus, Some(0));
         assert_eq!(message.attributes.priority, UPriority::UPRIORITY_CS4.into());
-        assert_eq!(message.attributes.reqid, Some(request_id).into());
+        assert_eq!(message.attributes.reqid, Some(request_message_id).into());
         assert_eq!(message.attributes.sink, Some(reply_to_address).into());
         assert_eq!(message.attributes.source, Some(method_to_invoke).into());
         assert_eq!(message.attributes.ttl, Some(0));
@@ -765,18 +917,24 @@ mod tests {
     #[test]
     fn test_build_retains_all_response_attributes() {
         let uuid_builder = UUIDBuilder::new();
+        let message_id = uuid_builder.build();
         let request_id = uuid_builder.build();
         let method_to_invoke = UUri::try_from(METHOD_TO_INVOKE)
             .expect("should have been able to create destination UUri");
         let reply_to_address = UUri::try_from(REPLY_TO_ADDRESS)
             .expect("should have been able to create reply-to UUri");
-        let message = UMessageBuilder::response(&reply_to_address, &request_id, &method_to_invoke)
-            .with_comm_status(0)
-            .with_priority(UPriority::UPRIORITY_CS4)
-            .with_ttl(0)
-            .build(&uuid_builder)
-            .expect("should have been able to create message");
-        assert!(message.attributes.id.is_some());
+        let message = UMessageBuilder::response(
+            reply_to_address.clone(),
+            request_id.clone(),
+            method_to_invoke.clone(),
+        )
+        .with_message_id(message_id.clone())
+        .with_comm_status(0)
+        .with_priority(UPriority::UPRIORITY_CS4)
+        .with_ttl(0)
+        .build()
+        .expect("should have been able to create message");
+        assert_eq!(message.attributes.id, Some(message_id).into());
         assert_eq!(message.attributes.commstatus, Some(0));
         assert_eq!(message.attributes.priority, UPriority::UPRIORITY_CS4.into());
         assert_eq!(message.attributes.reqid, Some(request_id).into());


### PR DESCRIPTION
Changed UMessageBuilder to support being used as a message template
for creating multiple message consecutively using different message
ID and payload only.

Moved message type specific checks of UAttributesValidator to
concrete validator structs to improve encapsulation.