### PR TITLE
`UTransport::registerListener()` using marker trait dispatch for message types + generic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,8 @@ mod up_core_api {
 
 // cloudevent-proto, generated and augmented types
 pub mod cloudevents;
+pub mod ulistener;
+
 mod proto_cloudevents {
     include!(concat!(env!("OUT_DIR"), "/cloudevents/mod.rs"));
     pub(crate) use self::cloudevents::cloud_event::*; // re-export for crate use, remove triple-redundant names

--- a/src/ulistener.rs
+++ b/src/ulistener.rs
@@ -164,12 +164,10 @@ mod tests {
                             return true;
                         }
                     }
-                    Err(_e) => {
-                        return false;
-                    }
+                    Err(_e) => {}
                 }
             }
-            return false;
+            false
         }
     }
 

--- a/src/ulistener.rs
+++ b/src/ulistener.rs
@@ -54,37 +54,37 @@ mod tests {
 
     #[async_trait]
     impl UTransport for UpClientFoo {
-        async fn send(&self, message: UMessage) -> Result<(), UStatus> {
+        async fn send(&self, _message: UMessage) -> Result<(), UStatus> {
             todo!()
         }
 
-        async fn receive(&self, topic: UUri) -> Result<UMessage, UStatus> {
+        async fn receive(&self, _topic: UUri) -> Result<UMessage, UStatus> {
             todo!()
         }
 
         async fn register_listener(
             &self,
-            topic: UUri,
+            _topic: UUri,
             listener: ListenerType,
         ) -> Result<String, UStatus> {
             match listener {
-                ListenerType::Notification(notificationListener) => {
+                ListenerType::Notification(_notification_listener) => {
                     // implement Foo-specific means of allowing protocol to perform filtering for Notifications
                     todo!()
                 }
-                ListenerType::Publish(publishListener) => {
+                ListenerType::Publish(_publish_listener) => {
                     // implement Foo-specific means of allowing protocol to perform filtering for Publish
                     todo!()
                 }
-                ListenerType::Request(requestListener) => {
+                ListenerType::Request(_request_listener) => {
                     // implement Foo-specific means of allowing protocol to perform filtering for Request
                     todo!()
                 }
-                ListenerType::Response(responseListener) => {
+                ListenerType::Response(_response_listener) => {
                     // implement Foo-specific means of allowing protocol to perform filtering for Response
                     todo!()
                 }
-                ListenerType::Generic(genericListener) => {
+                ListenerType::Generic(generic_listener) => {
                     // assume that we have another thread / async task that's being pinged on each
                     // message received and that we skim thru listeners in order to check if each
                     // one is a match
@@ -94,13 +94,13 @@ mod tests {
                         UStatus::fail_with_code(UCode::INTERNAL, "Failed to get lock on listeners")
                     })?;
 
-                    listeners.push(genericListener);
+                    listeners.push(generic_listener);
                     Ok("here's your handle".to_string())
                 }
             }
         }
 
-        async fn unregister_listener(&self, topic: UUri, listener: &str) -> Result<(), UStatus> {
+        async fn unregister_listener(&self, _topic: UUri, _listener: &str) -> Result<(), UStatus> {
             todo!()
         }
     }
@@ -108,7 +108,7 @@ mod tests {
     struct MyClientFooNotificationListener;
 
     impl UListener for MyClientFooNotificationListener {
-        fn on_receive(&self, message: Result<UMessage, UStatus>) {
+        fn on_receive(&self, _message: Result<UMessage, UStatus>) {
             todo!()
         }
     }
@@ -118,7 +118,7 @@ mod tests {
     struct MyClientFooPublishListener;
 
     impl UListener for MyClientFooPublishListener {
-        fn on_receive(&self, message: Result<UMessage, UStatus>) {
+        fn on_receive(&self, _message: Result<UMessage, UStatus>) {
             todo!()
         }
     }
@@ -128,7 +128,7 @@ mod tests {
     struct MyClientFooRequestListener;
 
     impl UListener for MyClientFooRequestListener {
-        fn on_receive(&self, message: Result<UMessage, UStatus>) {
+        fn on_receive(&self, _message: Result<UMessage, UStatus>) {
             todo!()
         }
     }
@@ -138,7 +138,7 @@ mod tests {
     struct MyClientFooResponseListener;
 
     impl UListener for MyClientFooResponseListener {
-        fn on_receive(&self, message: Result<UMessage, UStatus>) {
+        fn on_receive(&self, _message: Result<UMessage, UStatus>) {
             todo!()
         }
     }
@@ -150,7 +150,7 @@ mod tests {
     }
 
     impl UListener for MyClientFooPriorityMatcherListener {
-        fn on_receive(&self, message: Result<UMessage, UStatus>) {
+        fn on_receive(&self, _message: Result<UMessage, UStatus>) {
             todo!()
         }
     }
@@ -164,7 +164,7 @@ mod tests {
                             return true;
                         }
                     }
-                    Err(e) => {
+                    Err(_e) => {
                         return false;
                     }
                 }
@@ -177,37 +177,37 @@ mod tests {
 
     #[async_trait]
     impl UTransport for UpClientBar {
-        async fn send(&self, message: UMessage) -> Result<(), UStatus> {
+        async fn send(&self, _message: UMessage) -> Result<(), UStatus> {
             todo!()
         }
 
-        async fn receive(&self, topic: UUri) -> Result<UMessage, UStatus> {
+        async fn receive(&self, _topic: UUri) -> Result<UMessage, UStatus> {
             todo!()
         }
 
         async fn register_listener(
             &self,
-            topic: UUri,
+            _topic: UUri,
             listener: ListenerType,
         ) -> Result<String, UStatus> {
             match listener {
-                ListenerType::Notification(notificationListener) => {
+                ListenerType::Notification(_notification_listener) => {
                     // implement Bar-specific means of allowing protocol to perform filtering for Notifications
                     todo!()
                 }
-                ListenerType::Publish(publishListener) => {
+                ListenerType::Publish(_publish_listener) => {
                     // implement Bar-specific means of allowing protocol to perform filtering for Publish
                     todo!()
                 }
-                ListenerType::Request(requestListener) => {
+                ListenerType::Request(_request_listener) => {
                     // implement Bar-specific means of allowing protocol to perform filtering for Request
                     todo!()
                 }
-                ListenerType::Response(responseListener) => {
+                ListenerType::Response(_response_listener) => {
                     // implement Bar-specific means of allowing protocol to perform filtering for Response
                     todo!()
                 }
-                ListenerType::Generic(genericListener) => {
+                ListenerType::Generic(_generic_listener) => {
                     // for UpClientBar we only handle this at the protocol level, with no generic
                     // mechanism to handle incoming messages
                     return Err(UStatus::fail_with_code(
@@ -218,7 +218,7 @@ mod tests {
             }
         }
 
-        async fn unregister_listener(&self, topic: UUri, listener: &str) -> Result<(), UStatus> {
+        async fn unregister_listener(&self, _topic: UUri, _listener: &str) -> Result<(), UStatus> {
             todo!()
         }
     }

--- a/src/ulistener.rs
+++ b/src/ulistener.rs
@@ -1,0 +1,131 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use crate::{UMessage, UStatus, UUri};
+
+pub trait UListener {
+    fn on_receive(&self, message: Result<UMessage, UStatus>);
+}
+
+pub trait NotificationUListener: UListener {}
+
+pub trait PublishUListener: UListener {}
+
+pub trait RequestUListener: UListener {}
+
+pub trait ResponseUListener: UListener {}
+
+pub trait GenericUListener: UListener {}
+
+pub enum ListenerType {
+    Notification(Box<dyn NotificationUListener>),
+    Publish(Box<dyn PublishUListener>),
+    Request(Box<dyn RequestUListener>),
+    Response(Box<dyn ResponseUListener>),
+    Generic(UUri, Box<dyn GenericUListener>),
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ulistener::{
+        ListenerType, NotificationUListener, PublishUListener, RequestUListener, ResponseUListener,
+        UListener,
+    };
+    use crate::{UMessage, UStatus, UTransport, UUri};
+    use async_trait::async_trait;
+
+    struct UpClientFoo;
+
+    #[async_trait]
+    impl UTransport for UpClientFoo {
+        async fn send(&self, message: UMessage) -> Result<(), UStatus> {
+            todo!()
+        }
+
+        async fn receive(&self, topic: UUri) -> Result<UMessage, UStatus> {
+            todo!()
+        }
+
+        async fn register_listener(
+            &self,
+            topic: UUri,
+            listener: ListenerType,
+        ) -> Result<String, UStatus> {
+            match listener {
+                ListenerType::Notification(notificationListener) => {
+                    // implement Foo-specific means of allowing protocol to perform filtering for Notifications
+                    todo!()
+                }
+                ListenerType::Publish(publishListener) => {
+                    // implement Foo-specific means of allowing protocol to perform filtering for Publish
+                    todo!()
+                }
+                ListenerType::Request(requestListener) => {
+                    // implement Foo-specific means of allowing protocol to perform filtering for Request
+                    todo!()
+                }
+                ListenerType::Response(responseListener) => {
+                    // implement Foo-specific means of allowing protocol to perform filtering for Response
+                    todo!()
+                }
+                ListenerType::Generic(uuri, genericListener) => {
+                    todo!()
+                }
+            }
+        }
+
+        async fn unregister_listener(&self, topic: UUri, listener: &str) -> Result<(), UStatus> {
+            todo!()
+        }
+    }
+
+    struct MyClientFooNotificationListener;
+
+    impl UListener for MyClientFooNotificationListener {
+        fn on_receive(&self, message: Result<UMessage, UStatus>) {
+            todo!()
+        }
+    }
+
+    impl NotificationUListener for MyClientFooNotificationListener {}
+
+    struct MyClientFooPublishListener;
+
+    impl UListener for MyClientFooPublishListener {
+        fn on_receive(&self, message: Result<UMessage, UStatus>) {
+            todo!()
+        }
+    }
+
+    impl PublishUListener for MyClientFooPublishListener {}
+
+    struct MyClientFooRequestListener;
+
+    impl UListener for MyClientFooRequestListener {
+        fn on_receive(&self, message: Result<UMessage, UStatus>) {
+            todo!()
+        }
+    }
+
+    impl RequestUListener for MyClientFooRequestListener {}
+
+    struct MyClientFooResponseListener;
+
+    impl UListener for MyClientFooResponseListener {
+        fn on_receive(&self, message: Result<UMessage, UStatus>) {
+            todo!()
+        }
+    }
+
+    impl ResponseUListener for MyClientFooResponseListener {}
+}

--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -13,6 +13,7 @@
 
 use async_trait::async_trait;
 
+use crate::ulistener::ListenerType;
 use crate::{UMessage, UStatus, UUri};
 
 /// `UTransport` is the uP-L1 interface that provides a common API for uE developers to send and receive messages.
@@ -70,7 +71,7 @@ pub trait UTransport {
     async fn register_listener(
         &self,
         topic: UUri,
-        listener: Box<dyn Fn(Result<UMessage, UStatus>) + Send + Sync + 'static>,
+        listener: ListenerType,
     ) -> Result<String, UStatus>;
 
     /// Unregisters a listener for a given topic.


### PR DESCRIPTION
Hey there folks :wave: 

After chatting with @tamarafischer and @stevenhartley and reading through the [equivalent PR over on `up-java`](https://github.com/eclipse-uprotocol/up-java/pull/93), I tried my hand at something similar over here in Rust.

This is very much in draft status to garner feedback! :slightly_smiling_face: 