### PR TITLE
Aligning with `UTransport::register_listener()` and `UTransport::unregister_listener()` with `UListener`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,4 @@ ureq = { version = "2.9.1", features = ["proxy-from-env"] }
 
 [dev-dependencies]
 test-case = { version = "3.3" }
+async-std = { version = "1.12.0" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ pub use ustatus::{UCode, UStatus};
 
 mod utransport;
 pub use utransport::UTransport;
+pub mod ulistener;
 
 mod uuid;
 pub use uuid::{UUIDBuilder, UUID};
@@ -97,6 +98,7 @@ pub use up_core_api::utwin;
 // cloudevent-proto, generated and augmented types
 #[cfg(feature = "cloudevents")]
 pub mod cloudevents;
+
 #[cfg(feature = "cloudevents")]
 mod proto_cloudevents {
     include!(concat!(env!("OUT_DIR"), "/cloudevents/mod.rs"));

--- a/src/ulistener.rs
+++ b/src/ulistener.rs
@@ -1,11 +1,56 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 use std::any::Any;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use crate::{UMessage, UStatus};
 
+/// `UListener` is the uP-L1 interface that provides a means to create listeners which are registered to `UTransport`
+///
+/// Implementations of `UListener` contain the details for what should occur when a message is received
+/// For more information, please refer to
+/// [uProtocol Specification](https://github.com/eclipse-uprotocol/uprotocol-spec/blob/main/up-l1/README.adoc).
 pub trait UListener: Debug + Any + Send + Sync {
+    /// This function is necessary to disambiguate concrete implementations of UListener
+    /// Arises from limitations surrounding Rust's type system
+    ///
+    /// Each concrete implementation will implement this function in the same way:
+    /// ```
+    /// use std::any::Any;
+    /// use up_rust::ulistener::UListener;
+    /// use up_rust::{UMessage, UStatus};
+    ///
+    /// #[derive(Debug)]
+    /// struct ListenerFoo;
+    /// impl UListener for ListenerFoo {
+    ///     fn as_any(&self) -> &dyn Any {
+    ///         self
+    ///     }
+    ///
+    ///     fn on_receive(&self, received: Result<UMessage, UStatus>) {
+    ///         todo!()
+    ///     }
+    ///
+    /// }
+    /// ```
     fn as_any(&self) -> &dyn Any;
 
+    /// Performs some action on receipt
+    ///
+    /// # Arguments
+    ///
+    /// * `received` - Either the message or error `UStatus` received
     fn on_receive(&self, received: Result<UMessage, UStatus>);
 }
 

--- a/src/ulistener.rs
+++ b/src/ulistener.rs
@@ -11,10 +11,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+use crate::{UMessage, UStatus};
 use std::any::Any;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
-use crate::{UMessage, UStatus};
 
 /// `UListener` is the uP-L1 interface that provides a means to create listeners which are registered to `UTransport`
 ///

--- a/src/ulistener.rs
+++ b/src/ulistener.rs
@@ -1,0 +1,24 @@
+use std::any::Any;
+use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
+use crate::{UMessage, UStatus};
+
+pub trait UListener: Debug + Any + Send + Sync {
+    fn as_any(&self) -> &dyn Any;
+
+    fn on_receive(&self, received: Result<UMessage, UStatus>);
+}
+
+impl Hash for dyn UListener {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_any().type_id().hash(state);
+    }
+}
+
+impl PartialEq for dyn UListener {
+    fn eq(&self, other: &Self) -> bool {
+        Any::type_id(self) == Any::type_id(other)
+    }
+}
+
+impl Eq for dyn UListener {}

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -11,6 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+use std::hash::{Hash, Hasher};
 use std::io::Write;
 use std::str::FromStr;
 
@@ -548,6 +549,16 @@ impl TryFrom<Vec<u8>> for UUri {
         UUri::try_from(micro_uri.as_slice())
     }
 }
+
+impl Hash for UUri {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.authority.hash(state);
+        self.entity.hash(state);
+        self.resource.hash(state);
+    }
+}
+
+impl Eq for UUri {}
 
 impl UUri {
     /// Builds a fully resolved `UUri` from the serialized long format and the serialized micro format.

--- a/src/uri/uauthority.rs
+++ b/src/uri/uauthority.rs
@@ -11,8 +11,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use std::hash::{Hash, Hasher};
 use bytes::BufMut;
+use std::hash::{Hash, Hasher};
 
 pub use crate::up_core_api::uri::{uauthority::Number, UAuthority};
 use crate::uri::UUriError;

--- a/src/uri/uauthority.rs
+++ b/src/uri/uauthority.rs
@@ -11,6 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+use std::hash::{Hash, Hasher};
 use bytes::BufMut;
 
 pub use crate::up_core_api::uri::{uauthority::Number, UAuthority};
@@ -20,6 +21,26 @@ const REMOTE_IPV4_BYTES: usize = 4;
 const REMOTE_IPV6_BYTES: usize = 16;
 const REMOTE_ID_MINIMUM_BYTES: usize = 1;
 const REMOTE_ID_MAXIMUM_BYTES: usize = 255;
+
+impl Hash for UAuthority {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.number.hash(state);
+    }
+}
+
+impl Eq for UAuthority {}
+
+impl Hash for Number {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            Number::Ip(ip) => ip.hash(state),
+            Number::Id(id) => id.hash(state),
+        }
+    }
+}
+
+impl Eq for Number {}
 
 /// uProtocol defines a [Micro-URI format](https://github.com/eclipse-uprotocol/up-spec/blob/main/basics/uri.adoc#42-micro-uris), which contains
 /// a type field for which addressing mode is used by a MicroUri. The `AddressType` type implements this definition.

--- a/src/uri/uentity.rs
+++ b/src/uri/uentity.rs
@@ -11,9 +11,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use std::hash::{Hash, Hasher};
 pub use crate::up_core_api::uri::UEntity;
 use crate::uri::UUriError;
+use std::hash::{Hash, Hasher};
 
 const UENTITY_ID_LENGTH: usize = 16;
 const UENTITY_ID_VALID_BITMASK: u32 = 0xffff << UENTITY_ID_LENGTH;

--- a/src/uri/uentity.rs
+++ b/src/uri/uentity.rs
@@ -11,6 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+use std::hash::{Hash, Hasher};
 pub use crate::up_core_api::uri::UEntity;
 use crate::uri::UUriError;
 
@@ -18,6 +19,15 @@ const UENTITY_ID_LENGTH: usize = 16;
 const UENTITY_ID_VALID_BITMASK: u32 = 0xffff << UENTITY_ID_LENGTH;
 const UENTITY_MAJOR_VERSION_LENGTH: usize = 8;
 const UENTITY_MAJOR_VERSION_VALID_BITMASK: u32 = 0xffffff << UENTITY_MAJOR_VERSION_LENGTH;
+
+impl Hash for UEntity {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+        self.version_major.hash(state);
+    }
+}
+
+impl Eq for UEntity {}
 
 impl UEntity {
     pub fn has_id(&self) -> bool {

--- a/src/uri/uresource.rs
+++ b/src/uri/uresource.rs
@@ -11,9 +11,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-use std::hash::{Hash, Hasher};
 pub use crate::up_core_api::uri::UResource;
 use crate::uri::UUriError;
+use std::hash::{Hash, Hasher};
 
 const URESOURCE_ID_LENGTH: usize = 16;
 const URESOURCE_ID_VALID_BITMASK: u32 = 0xffff << URESOURCE_ID_LENGTH;

--- a/src/uri/uresource.rs
+++ b/src/uri/uresource.rs
@@ -11,11 +11,20 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+use std::hash::{Hash, Hasher};
 pub use crate::up_core_api::uri::UResource;
 use crate::uri::UUriError;
 
 const URESOURCE_ID_LENGTH: usize = 16;
 const URESOURCE_ID_VALID_BITMASK: u32 = 0xffff << URESOURCE_ID_LENGTH;
+
+impl Hash for UResource {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+impl Eq for UResource {}
 
 impl UResource {
     pub fn has_id(&self) -> bool {

--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -61,10 +61,6 @@ pub trait UTransport {
     /// * `address` - The (resolved) address to register the listener for.
     /// * `listener` - The listener to invoke.
     ///
-    /// # Returns
-    ///
-    /// An identifier that can be used for [unregistering the listener](Self::unregister_listener) again.
-    ///
     /// # Errors
     ///
     /// Returns an error if the listener could not be registered.
@@ -263,6 +259,17 @@ mod tests {
         let umessage = UMessage::default();
         let check_on_receive_res =  up_client_foo.check_on_receive(&uuri_1, &umessage);
         assert_eq!(check_on_receive_res, Ok(()));
+    }
+
+    #[test]
+    fn test_if_no_listeners() {
+        let up_client_foo = UPClientFoo::new();
+        let uuri_1 = uuri_factory(1);
+
+        let umessage = UMessage::default();
+        let check_on_receive_res =  up_client_foo.check_on_receive(&uuri_1, &umessage);
+
+        assert_eq!(check_on_receive_res.is_err(), true);
     }
 
 }

--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -101,6 +101,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     struct UPClientFoo {
+        #[allow(clippy::type_complexity)]
         listeners: Arc<Mutex<HashMap<UUri, HashSet<Box<dyn UListener>>>>>,
     }
 
@@ -111,6 +112,7 @@ mod tests {
             }
         }
 
+        #[allow(clippy::type_complexity)]
         pub fn get_hashmap(&self) -> Arc<Mutex<HashMap<UUri, HashSet<Box<dyn UListener>>>>> {
             self.listeners.clone()
         }
@@ -153,7 +155,7 @@ mod tests {
             listener: Box<dyn UListener>,
         ) -> Result<(), UStatus> {
             let mut topics_listeners = self.listeners.lock().unwrap();
-            let listeners = topics_listeners.entry(topic).or_insert_with(HashSet::new);
+            let listeners = topics_listeners.entry(topic).or_default();
             listeners.insert(listener);
 
             Ok(())
@@ -291,6 +293,6 @@ mod tests {
         let umessage = UMessage::default();
         let check_on_receive_res = up_client_foo.check_on_receive(&uuri_1, &umessage);
 
-        assert_eq!(check_on_receive_res.is_err(), true);
+        assert!(check_on_receive_res.is_err());
     }
 }


### PR DESCRIPTION
Hey there :wave: 

Based on #65, I took my shot at aligning our `UTransport` trait closer to the spec.

In particular, I have removed the requirement for the implementation to explicitly manage listeners using `String` identifiers, instead leaning on concrete implementations of the `UListener` trait.

This change is to align with [`registerListener()`](https://github.com/eclipse-uprotocol/up-spec/tree/main/up-l1#22-registerlistener) and [`unregisterListener()`](https://github.com/eclipse-uprotocol/up-spec/tree/main/up-l1#22-registerlistener) by bringing in a [`UListener`](https://github.com/eclipse-uprotocol/up-spec/tree/main/up-l1#1-ulistener) trait.

As you read the code, you can definitely see there were compromises that had to be made to accomplish this.

Let me list the ways:
* `UListener` must have another function `as_any()` which must be implemented by the concrete impls of it to always return `self`
   * IMHO not a _huge_ deal, but we could go a step farther by writing a proc macro that people would call instead which could ensure this is always performed
   * I'm also open to any suggestions on how `UListener` could be tweaked to remove this requirement!
* If we wish to `unregister_listener()`, we must instantiate another `Box<dyn UListener>` from the concrete type to do so
   * Kinda annoying, but not a deal-breaker IMHO

In addition, it does make it quite a bit more annoying because instead of being able to pass in any boxed function anywhere that meets the signature, you must now first implement UListener for each and every different function that you wish to be able to register with `UTransport`. This is not a small change and pretty annoying in my opinion.

I'm looking to see how this would impact current and future implementations of `UTransport` for UPClients. Feedback would be great from @AnotherDaniel, @sophokles73, @evshary in particular :slightly_smiling_face: 