### PR TITLE
Aligning with `UTransport::register_listener()` and `UTransport::unregister_listener()` with `UListener` (this time using instance equality)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -594,7 +594,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -658,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
 dependencies = [
  "bytes",
  "fnv",
@@ -1064,7 +1064,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1075,9 +1075,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.101"
+version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
@@ -1114,14 +1114,14 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -1463,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -1476,9 +1476,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1501,7 +1501,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1596,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.55"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1662,7 +1662,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1673,7 +1673,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
  "test-case-core",
 ]
 
@@ -1694,7 +1694,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1714,9 +1714,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1927,7 +1927,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
  "wasm-bindgen-shared",
 ]
 
@@ -1961,7 +1961,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.58",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,7 @@ mod ustatus;
 pub use ustatus::{UCode, UStatus};
 
 mod utransport;
-pub use utransport::UTransport;
-
+pub use utransport::{ComparableListener, UListener, UTransport};
 mod uuid;
 pub use uuid::{UUIDBuilder, UUID};
 
@@ -95,6 +94,7 @@ pub use up_core_api::utwin;
 // cloudevent-proto, generated and augmented types
 #[cfg(feature = "cloudevents")]
 pub mod cloudevents;
+
 #[cfg(feature = "cloudevents")]
 mod proto_cloudevents {
     include!(concat!(env!("OUT_DIR"), "/cloudevents/mod.rs"));

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -11,6 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+use std::hash::{Hash, Hasher};
 use std::io::Write;
 use std::str::FromStr;
 
@@ -548,6 +549,16 @@ impl TryFrom<Vec<u8>> for UUri {
         UUri::try_from(micro_uri.as_slice())
     }
 }
+
+impl Hash for UUri {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.authority.hash(state);
+        self.entity.hash(state);
+        self.resource.hash(state);
+    }
+}
+
+impl Eq for UUri {}
 
 impl UUri {
     /// Builds a fully resolved `UUri` from the serialized long format and the serialized micro format.

--- a/src/uri/uauthority.rs
+++ b/src/uri/uauthority.rs
@@ -12,6 +12,7 @@
  ********************************************************************************/
 
 use bytes::BufMut;
+use std::hash::{Hash, Hasher};
 
 pub use crate::up_core_api::uri::{uauthority::Number, UAuthority};
 use crate::uri::UUriError;
@@ -20,6 +21,26 @@ const REMOTE_IPV4_BYTES: usize = 4;
 const REMOTE_IPV6_BYTES: usize = 16;
 const REMOTE_ID_MINIMUM_BYTES: usize = 1;
 const REMOTE_ID_MAXIMUM_BYTES: usize = 255;
+
+impl Hash for UAuthority {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.number.hash(state);
+    }
+}
+
+impl Eq for UAuthority {}
+
+impl Hash for Number {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            Number::Ip(ip) => ip.hash(state),
+            Number::Id(id) => id.hash(state),
+        }
+    }
+}
+
+impl Eq for Number {}
 
 /// uProtocol defines a [Micro-URI format](https://github.com/eclipse-uprotocol/up-spec/blob/main/basics/uri.adoc#42-micro-uris), which contains
 /// a type field for which addressing mode is used by a MicroUri. The `AddressType` type implements this definition.

--- a/src/uri/uentity.rs
+++ b/src/uri/uentity.rs
@@ -13,11 +13,21 @@
 
 pub use crate::up_core_api::uri::UEntity;
 use crate::uri::UUriError;
+use std::hash::{Hash, Hasher};
 
 const UENTITY_ID_LENGTH: usize = 16;
 const UENTITY_ID_VALID_BITMASK: u32 = 0xffff << UENTITY_ID_LENGTH;
 const UENTITY_MAJOR_VERSION_LENGTH: usize = 8;
 const UENTITY_MAJOR_VERSION_VALID_BITMASK: u32 = 0xffffff << UENTITY_MAJOR_VERSION_LENGTH;
+
+impl Hash for UEntity {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+        self.version_major.hash(state);
+    }
+}
+
+impl Eq for UEntity {}
 
 impl UEntity {
     pub fn has_id(&self) -> bool {

--- a/src/uri/uresource.rs
+++ b/src/uri/uresource.rs
@@ -13,9 +13,18 @@
 
 pub use crate::up_core_api::uri::UResource;
 use crate::uri::UUriError;
+use std::hash::{Hash, Hasher};
 
 const URESOURCE_ID_LENGTH: usize = 16;
 const URESOURCE_ID_VALID_BITMASK: u32 = 0xffff << URESOURCE_ID_LENGTH;
+
+impl Hash for UResource {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+impl Eq for UResource {}
 
 impl UResource {
     pub fn has_id(&self) -> bool {

--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -12,13 +12,122 @@
  ********************************************************************************/
 
 use async_trait::async_trait;
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
+use std::sync::Arc;
 
 use crate::{UMessage, UStatus, UUri};
 
-/// `UTransport` is the uP-L1 interface that provides a common API for uE developers to send and receive messages.
+/// `UListener` is the uP-L1 interface that provides a means to create listeners which are registered to [`UTransport`]
 ///
-/// Implementations of `UTransport` contain the details for connecting to the underlying transport technology and
-/// sending `UMessage` using the configured technology. For more information, please refer to
+/// Implementations of `UListener` contain the details for what should occur when a message is received
+///
+/// For more information, please refer to
+/// [uProtocol Specification](https://github.com/eclipse-uprotocol/uprotocol-spec/blob/main/up-l1/README.adoc).
+///
+/// # Examples
+///
+/// ## Simple example
+///
+/// ```
+/// use up_rust::{UListener, UMessage, UStatus};
+///
+/// use async_trait::async_trait;
+/// use std::sync::{Arc, Mutex};
+///
+/// #[derive(Clone)]
+/// struct FooListener {
+///     inner_foo: Arc<Mutex<String>>
+/// }
+///
+/// #[async_trait]
+/// impl UListener for FooListener {
+///     async fn on_receive(&self, msg: UMessage) {
+///         let mut inner_foo = self.inner_foo.lock().unwrap();
+///         if let Some(payload) = msg.payload.as_ref() {
+///             if let Some(length) = payload.length.as_ref() {
+///                 *inner_foo = format!("latest message length: {length}");
+///             }
+///         }
+///     }
+///
+///     async fn on_error(&self, err: UStatus) {
+///         println!("uh oh, we got an error: {err:?}");
+///     }
+/// }
+/// ```
+///
+/// ## Long-running function needed when message received
+///
+/// ```
+/// use up_rust::{UListener, UMessage, UStatus};
+///
+/// use async_trait::async_trait;
+/// use async_std::task;
+/// use std::sync::{Arc, Mutex};
+///
+/// #[derive(Clone)]
+/// struct LongTaskListener;
+///
+/// async fn send_to_jupiter(message_for_jupiter: UMessage) {
+///     // send a message to Jupiter
+///     println!("Fly me to the moon... {message_for_jupiter}");
+/// }
+///
+/// #[async_trait]
+/// impl UListener for LongTaskListener {
+///     async fn on_receive(&self, msg: UMessage) {
+///         task::spawn(send_to_jupiter(msg));
+///     }
+///
+///     async fn on_error(&self, err: UStatus) {
+///         println!("unable to send to jupiter :( {err:?}");
+///     }
+/// }
+/// ```
+#[async_trait]
+pub trait UListener: 'static + Send + Sync {
+    /// Performs some action on receipt of a message
+    ///
+    /// # Parameters
+    ///
+    /// * `msg` - The message
+    ///
+    /// # Note for `UListener` implementers
+    ///
+    /// `on_receive()` is expected to return almost immediately. If it does not, it could potentially
+    /// block further message receipt. For long-running operations consider passing off received
+    /// data to a different async function to handle it and returning.
+    ///
+    /// # Note for `UTransport` implementers
+    ///
+    /// Because `on_receive()` is async you may choose to either `.await` it in the current context
+    /// or spawn it onto a new task and await there to allow current context to immediately continue.
+    async fn on_receive(&self, msg: UMessage);
+
+    /// Performs some action on receipt of an error
+    ///
+    /// # Parameters
+    ///
+    /// * `err` - The error as `UStatus`
+    ///
+    /// # Note for `UListener` implementers
+    ///
+    /// `on_error()` is expected to return almost immediately. If it does not, it could potentially
+    /// block further message receipt. For long-running operations consider passing off received
+    /// error to a different async function to handle it and returning.
+    ///
+    /// # Note for `UTransport` implementers
+    ///
+    /// Because `on_error()` is async you may choose to either `.await` it in the current context
+    /// or spawn it onto a new task and await there to allow current context to immediately continue.
+    async fn on_error(&self, err: UStatus);
+}
+
+/// [`UTransport`] is the uP-L1 interface that provides a common API for uE developers to send and receive messages.
+///
+/// Implementations of [`UTransport`] contain the details for connecting to the underlying transport technology and
+/// sending [`UMessage`][crate::UMessage] using the configured technology. For more information, please refer to
 /// [uProtocol Specification](https://github.com/eclipse-uprotocol/uprotocol-spec/blob/main/up-l1/README.adoc).
 #[async_trait]
 pub trait UTransport {
@@ -58,20 +167,85 @@ pub trait UTransport {
     /// # Arguments
     ///
     /// * `address` - The (resolved) address to register the listener for.
-    /// * `listener` - The listener to invoke.
-    ///
-    /// # Returns
-    ///
-    /// An identifier that can be used for [unregistering the listener](Self::unregister_listener) again.
+    /// * `listener` - The listener to invoke. Note that we do not take ownership to communicate
+    ///                that a caller should keep a copy to be able to call `unregister_listener()`
     ///
     /// # Errors
     ///
     /// Returns an error if the listener could not be registered.
+    ///
+    /// # Examples
+    ///
+    /// ## Registering a listener
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use up_rust::UListener;
+    /// # use up_rust::{UMessage, UStatus, UTransport, UUri};
+    /// # use async_trait::async_trait;
+    /// #
+    /// # pub struct MyTransport;
+    /// #
+    /// # impl MyTransport {
+    /// #     pub fn new()->Self {
+    /// #         Self
+    /// #     }
+    /// # }
+    /// #
+    /// # #[async_trait]
+    /// # impl UTransport for MyTransport {
+    /// #     async fn send(&self, _message: UMessage) -> Result<(), UStatus> {
+    /// #         todo!()
+    /// #     }
+    /// #
+    /// #     async fn receive(&self, _topic: UUri) -> Result<UMessage, UStatus> {
+    /// #         todo!()
+    /// #     }
+    /// #
+    /// #     async fn register_listener(&self, _topic: UUri, _listener: Arc<dyn UListener>) -> Result<(), UStatus> {
+    /// #         Ok(())
+    /// #     }
+    /// #
+    /// #     async fn unregister_listener(&self, _topic: UUri, _listener: Arc<dyn UListener>) -> Result<(), UStatus> {
+    /// #         Ok(())
+    /// #     }
+    /// # }
+    /// #
+    /// # #[derive(Clone)]
+    /// # pub struct MyListener;
+    /// #
+    /// # impl MyListener {
+    /// #     pub fn new() -> Self {
+    /// #         Self
+    /// #     }
+    /// # }
+    /// #
+    /// # #[async_trait]
+    /// # impl UListener for MyListener {
+    /// #     async fn on_receive(&self, msg: UMessage) {
+    /// #         todo!()
+    /// #     }
+    /// #
+    /// #     async fn on_error(&self, err: UStatus) {
+    /// #         todo!()
+    /// #     }
+    /// # }
+    /// #
+    /// # let my_transport = MyTransport::new();
+    /// # let my_uuri = UUri::default();
+    ///
+    /// // hang onto this listener...
+    /// let my_listener: Arc<dyn UListener> = Arc::new(MyListener::new());
+    /// // ...send a clone through when registering...
+    /// let register_result = my_transport.register_listener(my_uuri.clone(), my_listener.clone());
+    /// // ...and use the original we hung onto when unregistering
+    /// let unregister_result = my_transport.unregister_listener(my_uuri, my_listener);
+    /// ```
     async fn register_listener(
         &self,
         topic: UUri,
-        listener: Box<dyn Fn(Result<UMessage, UStatus>) + Send + Sync + 'static>,
-    ) -> Result<String, UStatus>;
+        listener: Arc<dyn UListener>,
+    ) -> Result<(), UStatus>;
 
     /// Unregisters a listener for a given topic.
     ///
@@ -80,10 +254,339 @@ pub trait UTransport {
     /// # Arguments
     ///
     /// * `topic` - Resolved topic uri where the listener was registered originally.
-    /// * `listener` - Identifier of the listener that should be unregistered.
+    /// * `listener` - Identifier of the listener that should be unregistered. Here we take ownership
+    ///                to communicate that this listener is now finished.
     ///
     /// # Errors
     ///
     /// Returns an error if the listener could not be unregistered, for example if the given listener does not exist.
-    async fn unregister_listener(&self, topic: UUri, listener: &str) -> Result<(), UStatus>;
+    async fn unregister_listener(
+        &self,
+        topic: UUri,
+        listener: Arc<dyn UListener>,
+    ) -> Result<(), UStatus>;
+}
+
+/// A wrapper type around UListener that can be used by `up-client-foo-rust` UPClient libraries
+/// to ease some common development scenarios when we want to compare [`UListener`][crate::UListener]
+///
+/// # Note
+///
+/// Not necessary for end-user uEs to use. Primarily intended for `up-client-foo-rust` UPClient libraries
+/// when implementing [`UTransport`]
+///
+/// # Rationale
+///
+/// The wrapper type is implemented such that it can be used in any location you may wish to
+/// hold a type implementing [`UListener`][crate::UListener]
+///
+/// Implements necessary traits to allow hashing, so that you may hold the wrapper type in
+/// collections which require that, such as a `HashMap` or `HashSet`
+#[derive(Clone)]
+pub struct ComparableListener {
+    listener: Arc<dyn UListener>,
+}
+
+impl ComparableListener {
+    pub fn new(listener: Arc<dyn UListener>) -> Self {
+        Self { listener }
+    }
+}
+
+/// Allows us to call the methods on the held `Arc<dyn UListener>` directly
+impl Deref for ComparableListener {
+    type Target = dyn UListener;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.listener
+    }
+}
+
+/// The `Hash` implementation uses the held `Arc` pointer so that the same hash should result only
+/// in the case that two [`ComparableListener`] were constructed with the same `Arc<T>` where `T`
+/// implements [`UListener`][crate::UListener]
+impl Hash for ComparableListener {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Arc::as_ptr(&self.listener).hash(state);
+    }
+}
+
+/// Uses pointer equality to ensure that two [`ComparableListener`] are equal only if they were
+/// constructed with the same `Arc<T>` where `T` implements [`UListener`][crate::UListener]
+impl PartialEq for ComparableListener {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.listener, &other.listener)
+    }
+}
+
+impl Eq for ComparableListener {}
+
+#[cfg(test)]
+mod tests {
+    use crate::ComparableListener;
+    use crate::UListener;
+    use crate::{Number, UAuthority, UCode, UMessage, UStatus, UTransport, UUri};
+    use async_std::task;
+    use async_trait::async_trait;
+    use std::collections::hash_map::Entry;
+    use std::collections::{HashMap, HashSet};
+    use std::sync::{Arc, Mutex};
+
+    struct UPClientFoo {
+        #[allow(clippy::type_complexity)]
+        listeners: Arc<Mutex<HashMap<UUri, HashSet<ComparableListener>>>>,
+    }
+
+    impl UPClientFoo {
+        pub fn new() -> Self {
+            Self {
+                listeners: Arc::new(Mutex::new(HashMap::new())),
+            }
+        }
+
+        pub fn check_on_receive(&self, uuri: &UUri, umessage: &UMessage) -> Result<(), UStatus> {
+            let mut topics_listeners = self.listeners.lock().unwrap();
+            let listeners = topics_listeners.entry(uuri.clone());
+            match listeners {
+                Entry::Vacant(_) => {
+                    return Err(UStatus::fail_with_code(
+                        UCode::NOT_FOUND,
+                        format!("No listeners registered for topic: {:?}", &uuri),
+                    ))
+                }
+                Entry::Occupied(mut e) => {
+                    let occupied = e.get_mut();
+
+                    if occupied.is_empty() {
+                        return Err(UStatus::fail_with_code(
+                            UCode::NOT_FOUND,
+                            format!("No listeners registered for topic: {:?}", &uuri),
+                        ));
+                    }
+
+                    for listener in occupied.iter() {
+                        let task_listener = listener.clone();
+                        let task_umessage = umessage.clone();
+                        task::spawn(async move { task_listener.on_receive(task_umessage).await });
+                    }
+                }
+            }
+
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl UTransport for UPClientFoo {
+        async fn send(&self, _message: UMessage) -> Result<(), UStatus> {
+            todo!()
+        }
+
+        async fn receive(&self, _topic: UUri) -> Result<UMessage, UStatus> {
+            todo!()
+        }
+
+        async fn register_listener(
+            &self,
+            topic: UUri,
+            listener: Arc<dyn UListener>,
+        ) -> Result<(), UStatus> {
+            let mut topics_listeners = self.listeners.lock().unwrap();
+            let listeners = topics_listeners.entry(topic).or_default();
+            let identified_listener = ComparableListener::new(listener);
+            let inserted = listeners.insert(identified_listener);
+
+            return match inserted {
+                true => Ok(()),
+                false => Err(UStatus::fail_with_code(
+                    UCode::ALREADY_EXISTS,
+                    "UUri + UListener pair already exists!",
+                )),
+            };
+        }
+
+        async fn unregister_listener(
+            &self,
+            topic: UUri,
+            listener: Arc<dyn UListener>,
+        ) -> Result<(), UStatus> {
+            let mut topics_listeners = self.listeners.lock().unwrap();
+            let listeners = topics_listeners.entry(topic.clone());
+            return match listeners {
+                Entry::Vacant(_) => Err(UStatus::fail_with_code(
+                    UCode::NOT_FOUND,
+                    format!("No listeners registered for topic: {:?}", &topic),
+                )),
+                Entry::Occupied(mut e) => {
+                    let occupied = e.get_mut();
+                    let identified_listener = ComparableListener::new(listener);
+                    let removed = occupied.remove(&identified_listener);
+
+                    match removed {
+                        true => Ok(()),
+                        false => Err(UStatus::fail_with_code(
+                            UCode::NOT_FOUND,
+                            "UUri + UListener not found!",
+                        )),
+                    }
+                }
+            };
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct ListenerBaz;
+    #[async_trait]
+    impl UListener for ListenerBaz {
+        async fn on_receive(&self, msg: UMessage) {
+            println!("Printing msg from ListenerBaz! received: {:?}", msg);
+        }
+
+        async fn on_error(&self, err: UStatus) {
+            println!("Printing err from ListenerBaz! received {:?}", err)
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct ListenerBar;
+    #[async_trait]
+    impl UListener for ListenerBar {
+        async fn on_receive(&self, msg: UMessage) {
+            println!("Printing msg from ListenerBar! received: {:?}", msg);
+        }
+
+        async fn on_error(&self, err: UStatus) {
+            println!("Printing err from ListenerBar! received: {:?}", err);
+        }
+    }
+
+    fn uuri_factory(uuri_index: u8) -> UUri {
+        match uuri_index {
+            1 => UUri {
+                authority: Some(UAuthority {
+                    name: Some("uuri_1".to_string()),
+                    number: Some(Number::Ip(vec![192, 168, 1, 200])),
+                    ..Default::default()
+                })
+                .into(),
+                ..Default::default()
+            },
+            _ => UUri::default(),
+        }
+    }
+
+    #[test]
+    fn test_register_and_receive() {
+        let up_client_foo = UPClientFoo::new();
+        let uuri_1 = uuri_factory(1);
+        let listener_baz: Arc<dyn UListener> = Arc::new(ListenerBaz);
+        let register_res =
+            task::block_on(up_client_foo.register_listener(uuri_1.clone(), listener_baz.clone()));
+        assert!(register_res.is_ok());
+
+        let umessage = UMessage::default();
+        let check_on_receive_res = up_client_foo.check_on_receive(&uuri_1, &umessage);
+        assert_eq!(check_on_receive_res, Ok(()));
+    }
+
+    #[test]
+    fn test_register_and_unregister() {
+        let up_client_foo = UPClientFoo::new();
+        let uuri_1 = uuri_factory(1);
+        let listener_baz: Arc<dyn UListener> = Arc::new(ListenerBaz);
+        let register_res =
+            task::block_on(up_client_foo.register_listener(uuri_1.clone(), listener_baz.clone()));
+        assert!(register_res.is_ok());
+
+        let umessage = UMessage::default();
+        let check_on_receive_res = up_client_foo.check_on_receive(&uuri_1, &umessage);
+        assert_eq!(check_on_receive_res, Ok(()));
+
+        let unregister_res =
+            task::block_on(up_client_foo.unregister_listener(uuri_1.clone(), listener_baz));
+        assert!(unregister_res.is_ok());
+
+        let umessage = UMessage::default();
+        let check_on_receive_res = up_client_foo.check_on_receive(&uuri_1, &umessage);
+        assert!(check_on_receive_res.is_err());
+    }
+
+    #[test]
+    fn test_register_multiple_listeners_on_one_uuri() {
+        let up_client_foo = UPClientFoo::new();
+        let uuri_1 = uuri_factory(1);
+        let listener_baz: Arc<dyn UListener> = Arc::new(ListenerBaz);
+        let listener_bar: Arc<dyn UListener> = Arc::new(ListenerBar);
+
+        let register_res =
+            task::block_on(up_client_foo.register_listener(uuri_1.clone(), listener_baz.clone()));
+        assert!(register_res.is_ok());
+
+        let register_res =
+            task::block_on(up_client_foo.register_listener(uuri_1.clone(), listener_bar.clone()));
+        assert!(register_res.is_ok());
+
+        let umessage = UMessage::default();
+        let check_on_receive_res = up_client_foo.check_on_receive(&uuri_1, &umessage);
+        assert_eq!(check_on_receive_res, Ok(()));
+
+        let unregister_baz_res =
+            task::block_on(up_client_foo.unregister_listener(uuri_1.clone(), listener_baz));
+        assert!(unregister_baz_res.is_ok());
+        let unregister_bar_res =
+            task::block_on(up_client_foo.unregister_listener(uuri_1.clone(), listener_bar));
+        assert!(unregister_bar_res.is_ok());
+
+        let check_on_receive_res = up_client_foo.check_on_receive(&uuri_1, &umessage);
+        assert!(check_on_receive_res.is_err());
+    }
+
+    #[test]
+    fn test_if_no_listeners() {
+        let up_client_foo = UPClientFoo::new();
+        let uuri_1 = uuri_factory(1);
+
+        let umessage = UMessage::default();
+        let check_on_receive_res = up_client_foo.check_on_receive(&uuri_1, &umessage);
+
+        assert!(check_on_receive_res.is_err());
+    }
+
+    #[test]
+    fn test_register_multiple_same_listeners_on_one_uuri() {
+        let up_client_foo = UPClientFoo::new();
+        let uuri_1 = uuri_factory(1);
+
+        let listener_baz: Arc<dyn UListener> = Arc::new(ListenerBaz);
+        let register_res =
+            task::block_on(up_client_foo.register_listener(uuri_1.clone(), listener_baz.clone()));
+        assert!(register_res.is_ok());
+
+        let register_res =
+            task::block_on(up_client_foo.register_listener(uuri_1.clone(), listener_baz.clone()));
+        assert!(register_res.is_err());
+
+        let listener_baz_completely_different: Arc<dyn UListener> = Arc::new(ListenerBaz);
+        let register_res = task::block_on(
+            up_client_foo
+                .register_listener(uuri_1.clone(), listener_baz_completely_different.clone()),
+        );
+        assert!(register_res.is_ok());
+
+        let umessage = UMessage::default();
+        let check_on_receive_res = up_client_foo.check_on_receive(&uuri_1, &umessage);
+        assert_eq!(check_on_receive_res, Ok(()));
+
+        let unregister_res = task::block_on(
+            up_client_foo.unregister_listener(uuri_1.clone(), listener_baz_completely_different),
+        );
+        assert!(unregister_res.is_ok());
+
+        let unregister_baz_res =
+            task::block_on(up_client_foo.unregister_listener(uuri_1.clone(), listener_baz));
+        assert!(unregister_baz_res.is_ok());
+
+        let check_on_receive_res = up_client_foo.check_on_receive(&uuri_1, &umessage);
+        assert!(check_on_receive_res.is_err());
+    }
 }


### PR DESCRIPTION
Hey there :wave: 

Based on #65, I took my (third!) shot at aligning our `UTransport` trait closer to the spec.

In particular, I have removed the requirement for the implementation to explicitly manage listeners using `String` identifiers, instead leaning on concrete implementations of the `UListener` trait.

This change is to align with [`registerListener()`](https://github.com/eclipse-uprotocol/up-spec/tree/main/up-l1#22-registerlistener) and [`unregisterListener()`](https://github.com/eclipse-uprotocol/up-spec/tree/main/up-l1#22-registerlistener) by bringing in a [`UListener`](https://github.com/eclipse-uprotocol/up-spec/tree/main/up-l1#1-ulistener) trait.

As you read the code, you can see that there was a need for a new wrapper type called `ListenerWrapper` around UListener in order to allow us to disambiguate between _specific instances_ of UListener. The wrapper is also hashable to make it easy to use within containers that require that such as `HashSet` and `HashMap`. The `ListenerWrapper` need only be used in the `up-client-foo-rust` implementation. uEs just impl `UListener`.

Largely resolves the issues I had with the first and second attempts over in #67 and #68 thanks to that wrapper type.

I'm looking to see how this would impact current and future implementations of `UTransport` for UPClients. Feedback would be great from @AnotherDaniel, @sophokles73, @evshary in particular :slightly_smiling_face: 

I [migrated `up-client-zenoh-rust` over to using `UListener`](https://github.com/eclipse-uprotocol/up-client-zenoh-rust/pull/19) to see how it'd work out if you want to see real-world usage.