### PR TITLE
Support Notification validator.

### DIFF
--- a/src/uattributes/uattributesvalidator.rs
+++ b/src/uattributes/uattributesvalidator.rs
@@ -722,12 +722,12 @@ mod tests {
     }
 
     #[test_case(Some(UUIDBuilder::new().build()), Some(origin()), None, None, false; "fails for missing destination")]
-    #[test_case(Some(UUIDBuilder::new().build()), Some(origin()), Some(destination()), None, true; "succeeds for both topic and destination")]
+    #[test_case(Some(UUIDBuilder::new().build()), Some(origin()), Some(destination()), None, true; "succeeds for both origin and destination")]
     #[test_case(Some(UUIDBuilder::new().build()), Some(origin()), Some(destination()), Some(100), true; "succeeds for valid attributes")]
-    #[test_case(Some(UUIDBuilder::new().build()), None, Some(destination()), None, false; "fails for missing topic")]
-    #[test_case(Some(UUIDBuilder::new().build()), Some(UUri::default()), Some(destination()), None, false; "fails for invalid topic")]
+    #[test_case(Some(UUIDBuilder::new().build()), None, Some(destination()), None, false; "fails for missing origin")]
+    #[test_case(Some(UUIDBuilder::new().build()), Some(UUri::default()), Some(destination()), None, false; "fails for invalid origin")]
     #[test_case(Some(UUIDBuilder::new().build()), Some(origin()), Some(UUri::default()), None, false; "fails for invalid destination")]
-    #[test_case(Some(UUIDBuilder::new().build()), None, None, None, false; "fails for neither topic nor destination")]
+    #[test_case(Some(UUIDBuilder::new().build()), None, None, None, false; "fails for neither origin nor destination")]
     #[test_case(None, Some(origin()), Some(destination()), None, false; "fails for missing message ID")]
     #[test_case(
         Some(UUID {

--- a/src/umessage/umessagebuilder.rs
+++ b/src/umessage/umessagebuilder.rs
@@ -14,7 +14,7 @@
 use bytes::Bytes;
 use protobuf::{Enum, EnumOrUnknown, Message};
 
-use crate::uattributes::UAttributesError;
+use crate::uattributes::{NotificationValidator, UAttributesError};
 use crate::{
     Data, PublishValidator, RequestValidator, ResponseValidator, UAttributes, UAttributesValidator,
     UCode, UMessage, UMessageType, UPayload, UPayloadFormat, UPriority, UUri, UUID,
@@ -151,7 +151,7 @@ impl UMessageBuilder {
     /// let message = UMessageBuilder::notification(origin.clone(), destination.clone())
     ///                    .with_message_id(uuid_builder.build())
     ///                    .build_with_payload("unexpected movement".into(), UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
-    /// assert_eq!(message.attributes.type_, UMessageType::UMESSAGE_TYPE_PUBLISH.into());
+    /// assert_eq!(message.attributes.type_, UMessageType::UMESSAGE_TYPE_NOTIFICATION.into());
     /// assert_eq!(message.attributes.priority, UPriority::UPRIORITY_CS1.into());
     /// assert_eq!(message.attributes.source, Some(origin).into());
     /// assert_eq!(message.attributes.sink, Some(destination).into());
@@ -160,8 +160,8 @@ impl UMessageBuilder {
     /// ```
     pub fn notification(origin: UUri, destination: UUri) -> UMessageBuilder {
         UMessageBuilder {
-            validator: Box::new(PublishValidator),
-            message_type: UMessageType::UMESSAGE_TYPE_PUBLISH,
+            validator: Box::new(NotificationValidator),
+            message_type: UMessageType::UMESSAGE_TYPE_NOTIFICATION,
             source: Some(origin),
             sink: Some(destination),
             ..Default::default()


### PR DESCRIPTION
Now the type in UAttributes supports Publish, Notification, Request and Response
https://github.com/eclipse-uprotocol/up-core-api/blob/main/uprotocol/uattributes.proto#L132

We should separate the validator of Publish and Notification.