### PR TITLE
Make Utransport-related traits async-usable

### DIFF
--- a/src/rpc/rpcclient.rs
+++ b/src/rpc/rpcclient.rs
@@ -18,10 +18,10 @@ use crate::{CallOptions, RpcMapperError, UMessage, UPayload, UUri};
 pub type RpcClientResult = Result<UMessage, RpcMapperError>;
 
 /// `RpcClient` is an interface used by code generators for uProtocol services defined in `.proto` files such as
-/// the core uProtocol services found in [uProtocol Core API](https://github.com/eclipse-uprotocol/uprotocol-core-api).
+/// the core uProtocol services found in [uProtocol Core API](https://github.com/eclipse-uprotocol/up-spec/tree/main/up-core-api).
 ///
 /// The trait provides a clean contract for mapping a RPC requiest to a response. For more details please refer to the
-/// [RpcClient Specifications](https://github.com/eclipse-uprotocol/uprotocol-spec/blob/main/up-l2/README.adoc).
+/// [RpcClient Specifications](https://github.com/eclipse-uprotocol/up-spec/blob/main/up-l2/rpcclient.adoc).
 #[async_trait]
 pub trait RpcClient: Send + Sync {
     /// Invokes a method on a remote service asynchronously.

--- a/src/rpc/rpcclient.rs
+++ b/src/rpc/rpcclient.rs
@@ -23,7 +23,7 @@ pub type RpcClientResult = Result<UMessage, RpcMapperError>;
 /// The trait provides a clean contract for mapping a RPC requiest to a response. For more details please refer to the
 /// [RpcClient Specifications](https://github.com/eclipse-uprotocol/uprotocol-spec/blob/main/up-l2/README.adoc).
 #[async_trait]
-pub trait RpcClient {
+pub trait RpcClient: Send + Sync {
     /// Invokes a method on a remote service asynchronously.
     ///
     /// This function is an API for clients to send an RPC request and receive a response.

--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -130,7 +130,7 @@ pub trait UListener: 'static + Send + Sync {
 /// sending [`UMessage`][crate::UMessage] using the configured technology. For more information, please refer to
 /// [uProtocol Specification](https://github.com/eclipse-uprotocol/uprotocol-spec/blob/main/up-l1/README.adoc).
 #[async_trait]
-pub trait UTransport {
+pub trait UTransport: Send + Sync {
     /// Sends a message using this transport's message exchange mechanism.
     ///
     /// # Arguments

--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -86,7 +86,7 @@ use crate::{UMessage, UStatus, UUri};
 /// }
 /// ```
 #[async_trait]
-pub trait UListener: 'static + Send + Sync {
+pub trait UListener: Send + Sync {
     /// Performs some action on receipt of a message
     ///
     /// # Parameters

--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -22,8 +22,7 @@ use crate::{UMessage, UStatus, UUri};
 ///
 /// Implementations of `UListener` contain the details for what should occur when a message is received
 ///
-/// For more information, please refer to
-/// [uProtocol Specification](https://github.com/eclipse-uprotocol/uprotocol-spec/blob/main/up-l1/README.adoc).
+/// For more information, please refer to [uProtocol Specification](https://github.com/eclipse-uprotocol/up-spec/blob/main/up-l1/README.adoc).
 ///
 /// # Examples
 ///
@@ -128,7 +127,7 @@ pub trait UListener: Send + Sync {
 ///
 /// Implementations of [`UTransport`] contain the details for connecting to the underlying transport technology and
 /// sending [`UMessage`][crate::UMessage] using the configured technology. For more information, please refer to
-/// [uProtocol Specification](https://github.com/eclipse-uprotocol/uprotocol-spec/blob/main/up-l1/README.adoc).
+/// [uProtocol Specification](https://github.com/eclipse-uprotocol/up-spec/blob/main/up-l1/README.adoc).
 #[async_trait]
 pub trait UTransport: Send + Sync {
     /// Sends a message using this transport's message exchange mechanism.


### PR DESCRIPTION
Based on up-streamer review discussion - we want these traits to be send-able between threads. 