### PR TITLE
Improve versatility of ComparableListener

### DIFF
--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -291,6 +291,10 @@ impl ComparableListener {
     pub fn new(listener: Arc<dyn UListener>) -> Self {
         Self { listener }
     }
+    /// Gets a clone of the wrapped reference to the listener.
+    pub fn into_inner(&self) -> Arc<dyn UListener> {
+        self.listener.clone()
+    }
 }
 
 /// Allows us to call the methods on the held `Arc<dyn UListener>` directly


### PR DESCRIPTION
Implementing UTransport based on ComparableListener may require
exposing the (interal) ComparableListener type to clients of UTransport
when it comes to invoking the listener.

Added an `into_inner` function for getting a clone of the reference to
the wrapped listener. This way, client code can easily transform a
ComparableListener back to its underlying listener type.