### PR TITLE
Fix nightly CI build next attempt

### DIFF
--- a/.github/workflows/verify-msrv.yaml
+++ b/.github/workflows/verify-msrv.yaml
@@ -32,7 +32,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@master
       with: 
         toolchain: ${{ env.RUST_TOOLCHAIN }}
-        components: msrv
     - name: check MSRV
       run: |
+        cargo install cargo-msrv
         cargo msrv --verify


### PR DESCRIPTION
Use documented way of installing cargo-msrv.