### PR TITLE
Add doctests (as nextest doesn't do these yet)

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -31,6 +31,9 @@ on:
       test_results_url:
         description: "URL of the test results artifact"
         value: ${{ jobs.nextest.outputs.test_results_url }}
+      doctest_results_url:
+        description: "URL of the doctest results artifact"
+        value: ${{ jobs.doctest.outputs.test_results_url }}
   workflow_dispatch:
 
 concurrency:
@@ -147,4 +150,26 @@ jobs:
         with:
           name: test-results
           path: testresults--all-features.json
-          
+
+  doctest:
+    # Run doctests separately, as nextest doesn't yet (https://github.com/nextest-rs/nextest/issues/16)
+    outputs:
+      test_results_url: ${{ steps.doctest_results.outputs.artifact-url }}
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with: 
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+      - name: Run doc tests
+        run: |
+          cargo test --doc --all-features > doctestresults--all-features.json
+      - name: Upload doctest results artifact
+        id: doctest_results
+        uses: actions/upload-artifact@v4
+        with:
+          name: doctest-results
+          path: doctestresults--all-features.json
+        

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -165,11 +165,10 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
       - name: Run doc tests
         run: |
-          cargo test --doc --all-features > doctestresults--all-features.json
+          RUSTC_BOOTSTRAP=1 cargo test --doc -- -Z unstable-options --format json --report-time > doctestresults--all-features.json
       - name: Upload doctest results artifact
         id: doctest_results
         uses: actions/upload-artifact@v4
         with:
           name: doctest-results
           path: doctestresults--all-features.json
-        


### PR DESCRIPTION
As has [come up recently](https://github.com/eclipse-uprotocol/up-rust/pull/98#issuecomment-2106745523), our check workflow doesn't yet run doctests. So this is adding an explicit doctest step.

(refer to last bullet in #84)