### PR TITLE
Do not use uuid crate for de/serializing UUIDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,6 +1026,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
 name = "parking"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,7 +1771,7 @@ dependencies = [
  "reqwest",
  "test-case",
  "url",
- "uuid",
+ "uuid-simd",
 ]
 
 [[package]]
@@ -1780,10 +1786,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "uuid"
-version = "1.8.0"
+name = "uuid-simd"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "value-bag"
@@ -1796,6 +1806,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,10 @@ protobuf = { version = "3.3" }
 rand = { version = "0.8" }
 regex = { version = "1.10" }
 url = { version = "2.5" }
-uuid = { version = "1.7", features = ["v8"] }
+uuid-simd = { version = "0.8", default-features = false, features = [
+    "std",
+    "detect",
+] }
 
 [build-dependencies]
 protobuf-codegen = { version = "3.3" }
@@ -59,3 +62,8 @@ reqwest = { version = "0.12", features = ["blocking"] }
 async-std = { version = "1.12.0", features = ["attributes"] }
 futures = { version = "0.3.30" }
 test-case = { version = "3.3" }
+
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
The uuid crate has been replaced with the uuid_simd crate for
serializing/parsing UUIDs to/from hyphenated strings.

The uuid_simd crate makes use of SIMD instructions, if available on
the CPU during runtime, which reduces the parsing time by up to 40%.