### PR TITLE
Fix build.rs script

### DIFF
--- a/src/core/udiscovery.rs
+++ b/src/core/udiscovery.rs
@@ -13,7 +13,6 @@
 
 pub use crate::up_core_api::udiscovery::{
     node::Type, notification::Operation, notification::Resources, AddNodesRequest,
-    DeleteNodesRequest, FindNodesRequest, FindNodesResponse, LookupUriResponse, Node,
-    NodeNotificationTopic, Notification, NotificationsRequest, ObserverInfo, PropertyValue,
-    UpdateNodeRequest, UpdatePropertyRequest,
+    DeleteNodesRequest, FindNodesRequest, FindNodesResponse, LookupUriResponse, Node, Notification,
+    NotificationsRequest, ObserverInfo, PropertyValue, UpdateNodeRequest, UpdatePropertyRequest,
 };

--- a/src/uattributes/upriority.rs
+++ b/src/uattributes/upriority.rs
@@ -15,7 +15,7 @@ use protobuf::EnumFull;
 
 use crate::uattributes::UAttributesError;
 pub use crate::up_core_api::uattributes::UPriority;
-use crate::up_core_api::uprotocol_options::exts::ce_name;
+use crate::up_core_api::uoptions::exts::ce_name;
 
 impl UPriority {
     /// Encodes this priority to a string.

--- a/src/umessage/umessagetype.rs
+++ b/src/umessage/umessagetype.rs
@@ -15,7 +15,7 @@ use protobuf::EnumFull;
 
 use crate::uattributes::UAttributesError;
 pub use crate::up_core_api::uattributes::UMessageType;
-use crate::up_core_api::uprotocol_options::exts::ce_name;
+use crate::up_core_api::uoptions::exts::ce_name;
 
 impl UMessageType {
     /// Gets this message type's CloudEvent type name.


### PR DESCRIPTION
The proto3 files from up-spec have been change to include version
information which has caused the build.rs script to fail to find the
included files. This has been fixed.