### PR TITLE
Use custom UMessage struct

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -34,7 +34,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 UPROTOCOL_BASE_URI, UPROTOCOL_VERSION
             )
             .as_str(),
-            format!("{}{}umessage.proto", UPROTOCOL_BASE_URI, UPROTOCOL_VERSION).as_str(),
             format!("{}{}ustatus.proto", UPROTOCOL_BASE_URI, UPROTOCOL_VERSION).as_str(),
             // not used in the SDK yet, but for completeness sake
             format!("{}{}file.proto", UPROTOCOL_BASE_URI, UPROTOCOL_VERSION).as_str(),

--- a/src/umessage.rs
+++ b/src/umessage.rs
@@ -14,11 +14,10 @@
 mod umessagebuilder;
 mod umessagetype;
 
+use bytes::Bytes;
 pub use umessagebuilder::*;
 
-pub use crate::up_core_api::umessage::UMessage;
-
-use crate::{UAttributesError, UPayloadFormat};
+use crate::{UAttributes, UAttributesError, UPayloadFormat};
 use protobuf::{well_known_types::any::Any, Message};
 
 #[derive(Debug)]
@@ -63,7 +62,22 @@ impl From<&str> for UMessageError {
     }
 }
 
+/// A container for a message's attributes and payload.
+#[derive(Debug, Clone)]
+pub struct UMessage {
+    attributes: UAttributes,
+    payload: Option<Bytes>,
+}
+
 impl UMessage {
+    pub fn attributes(&self) -> &UAttributes {
+        &self.attributes
+    }
+
+    pub fn payload(&self) -> Option<&Bytes> {
+        self.payload.as_ref()
+    }
+
     /// Extracts the payload-contained protobuf message from a `UMessage`.
     ///
     /// This function is used to extract strongly-typed data from a `UMessage` object,

--- a/src/umessage/README.md
+++ b/src/umessage/README.md
@@ -1,5 +1,0 @@
-# uProtocol Transport Interface & Data Model
-
-## Overview
-
-The purpose of this module is to provide an implementation of [uTransport API & Data Model](https://github.com/eclipse-uprotocol/uprotocol-spec/blob/main/up-l1/README.adoc). The transport API is used by all uE developers to send and receive messages across any transport. The interface is to be implemented by communication transport developers (i.e. developing a uTransport for SOME/IP, DDS, Zenoh, MQTT, etc...).

--- a/src/umessage/umessagebuilder.rs
+++ b/src/umessage/umessagebuilder.rs
@@ -39,8 +39,6 @@ pub struct UMessageBuilder {
     permission_level: Option<u32>,
     comm_status: Option<EnumOrUnknown<UCode>>,
     request_id: Option<UUID>,
-    payload: Option<Bytes>,
-    payload_format: UPayloadFormat,
 }
 
 impl Default for UMessageBuilder {
@@ -50,8 +48,6 @@ impl Default for UMessageBuilder {
             comm_status: None,
             message_type: UMessageType::UMESSAGE_TYPE_UNSPECIFIED,
             message_id: None,
-            payload: None,
-            payload_format: UPayloadFormat::UPAYLOAD_FORMAT_UNSPECIFIED,
             permission_level: None,
             priority: UPriority::UPRIORITY_UNSPECIFIED,
             request_id: None,
@@ -82,9 +78,9 @@ impl UMessageBuilder {
     /// let topic = UUri::try_from("my-vehicle/4210/1/B24D")?;
     /// let message = UMessageBuilder::publish(topic.clone())
     ///                    .build_with_payload("closed", UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
-    /// assert_eq!(message.attributes.type_, UMessageType::UMESSAGE_TYPE_PUBLISH.into());
-    /// assert_eq!(message.attributes.priority, UPriority::UPRIORITY_UNSPECIFIED.into());
-    /// assert_eq!(message.attributes.source, Some(topic).into());
+    /// assert_eq!(message.attributes().type_, UMessageType::UMESSAGE_TYPE_PUBLISH.into());
+    /// assert_eq!(message.attributes().priority, UPriority::UPRIORITY_UNSPECIFIED.into());
+    /// assert_eq!(message.attributes().source, Some(topic).into());
     /// # Ok(())
     /// # }
     /// ```
@@ -116,10 +112,10 @@ impl UMessageBuilder {
     /// let destination = UUri::try_from("my-cloud/CCDD/2/75FD")?;
     /// let message = UMessageBuilder::notification(origin.clone(), destination.clone())
     ///                    .build_with_payload("unexpected movement", UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
-    /// assert_eq!(message.attributes.type_, UMessageType::UMESSAGE_TYPE_NOTIFICATION.into());
-    /// assert_eq!(message.attributes.priority, UPriority::UPRIORITY_UNSPECIFIED.into());
-    /// assert_eq!(message.attributes.source, Some(origin).into());
-    /// assert_eq!(message.attributes.sink, Some(destination).into());
+    /// assert_eq!(message.attributes().type_, UMessageType::UMESSAGE_TYPE_NOTIFICATION.into());
+    /// assert_eq!(message.attributes().priority, UPriority::UPRIORITY_UNSPECIFIED.into());
+    /// assert_eq!(message.attributes().source, Some(origin).into());
+    /// assert_eq!(message.attributes().sink, Some(destination).into());
     /// # Ok(())
     /// # }
     /// ```
@@ -157,11 +153,11 @@ impl UMessageBuilder {
     /// let reply_to_address = UUri::try_from("my-cloud/BA4C/1/0")?;
     /// let message = UMessageBuilder::request(method_to_invoke.clone(), reply_to_address.clone(), 5000)
     ///                    .build_with_payload("lock", UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
-    /// assert_eq!(message.attributes.type_, UMessageType::UMESSAGE_TYPE_REQUEST.into());
-    /// assert_eq!(message.attributes.priority, UPriority::UPRIORITY_CS4.into());
-    /// assert_eq!(message.attributes.source, Some(reply_to_address).into());
-    /// assert_eq!(message.attributes.sink, Some(method_to_invoke).into());
-    /// assert_eq!(message.attributes.ttl, Some(5000));
+    /// assert_eq!(message.attributes().type_, UMessageType::UMESSAGE_TYPE_REQUEST.into());
+    /// assert_eq!(message.attributes().priority, UPriority::UPRIORITY_CS4.into());
+    /// assert_eq!(message.attributes().source, Some(reply_to_address).into());
+    /// assert_eq!(message.attributes().sink, Some(method_to_invoke).into());
+    /// assert_eq!(message.attributes().ttl, Some(5000));
     /// # Ok(())
     /// # }
     /// ```
@@ -204,11 +200,11 @@ impl UMessageBuilder {
     /// // `UMessageBuilder::response_for_request(&request_message.attributes)` instead
     /// let message = UMessageBuilder::response(reply_to_address.clone(), request_id.clone(), invoked_method.clone())
     ///                    .build()?;
-    /// assert_eq!(message.attributes.type_, UMessageType::UMESSAGE_TYPE_RESPONSE.into());
-    /// assert_eq!(message.attributes.priority, UPriority::UPRIORITY_CS4.into());
-    /// assert_eq!(message.attributes.source, Some(invoked_method).into());
-    /// assert_eq!(message.attributes.sink, Some(reply_to_address).into());
-    /// assert_eq!(message.attributes.reqid, Some(request_id).into());
+    /// assert_eq!(message.attributes().type_, UMessageType::UMESSAGE_TYPE_RESPONSE.into());
+    /// assert_eq!(message.attributes().priority, UPriority::UPRIORITY_CS4.into());
+    /// assert_eq!(message.attributes().source, Some(invoked_method).into());
+    /// assert_eq!(message.attributes().sink, Some(reply_to_address).into());
+    /// assert_eq!(message.attributes().reqid, Some(request_id).into());
     /// # Ok(())
     /// # }
     /// ```
@@ -253,14 +249,14 @@ impl UMessageBuilder {
     ///                           .with_message_id(request_message_id.clone()) // normally not needed, used only for asserts below
     ///                           .build_with_payload("lock", UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
     ///
-    /// let response_message = UMessageBuilder::response_for_request(&request_message.attributes)
+    /// let response_message = UMessageBuilder::response_for_request(request_message.attributes())
     ///                           .with_priority(UPriority::UPRIORITY_CS5)
     ///                           .build()?;
-    /// assert_eq!(response_message.attributes.type_, UMessageType::UMESSAGE_TYPE_RESPONSE.into());
-    /// assert_eq!(response_message.attributes.priority, UPriority::UPRIORITY_CS5.into());
-    /// assert_eq!(response_message.attributes.source, Some(method_to_invoke).into());
-    /// assert_eq!(response_message.attributes.sink, Some(reply_to_address).into());
-    /// assert_eq!(response_message.attributes.reqid, Some(request_message_id).into());
+    /// assert_eq!(response_message.attributes().type_, UMessageType::UMESSAGE_TYPE_RESPONSE.into());
+    /// assert_eq!(response_message.attributes().priority, UPriority::UPRIORITY_CS5.into());
+    /// assert_eq!(response_message.attributes().source, Some(method_to_invoke).into());
+    /// assert_eq!(response_message.attributes().sink, Some(reply_to_address).into());
+    /// assert_eq!(response_message.attributes().reqid, Some(request_message_id).into());
     /// # Ok(())
     /// # }
     /// ```
@@ -314,10 +310,10 @@ impl UMessageBuilder {
     ///                     // use new message ID but retain all other attributes
     ///                     .with_message_id(UUIDBuilder::build())
     ///                     .build_with_payload("open", UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
-    /// assert_ne!(message_one.attributes.id, message_two.attributes.id);
-    /// assert_eq!(message_one.attributes.source, message_two.attributes.source);
-    /// assert_eq!(message_one.attributes.priority, UPriority::UPRIORITY_CS2.into());
-    /// assert_eq!(message_two.attributes.priority, UPriority::UPRIORITY_CS2.into());
+    /// assert_ne!(message_one.attributes().id, message_two.attributes().id);
+    /// assert_eq!(message_one.attributes().source, message_two.attributes().source);
+    /// assert_eq!(message_one.attributes().priority, UPriority::UPRIORITY_CS2.into());
+    /// assert_eq!(message_two.attributes().priority, UPriority::UPRIORITY_CS2.into());
     /// # Ok(())
     /// # }
     /// ```
@@ -358,7 +354,7 @@ impl UMessageBuilder {
     /// let message = UMessageBuilder::publish(topic)
     ///                   .with_priority(UPriority::UPRIORITY_CS5)
     ///                   .build_with_payload("closed", UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
-    /// assert_eq!(message.attributes.priority, UPriority::UPRIORITY_CS5.into());
+    /// assert_eq!(message.attributes().priority, UPriority::UPRIORITY_CS5.into());
     /// # Ok(())
     /// # }
     /// ```
@@ -403,7 +399,7 @@ impl UMessageBuilder {
     /// let message = UMessageBuilder::response(reply_to_address, request_msg_id, invoked_method)
     ///                     .with_ttl(2000)
     ///                     .build()?;
-    /// assert_eq!(message.attributes.ttl, Some(2000));
+    /// assert_eq!(message.attributes().ttl, Some(2000));
     /// # Ok(())
     /// # }
     /// ```
@@ -438,7 +434,7 @@ impl UMessageBuilder {
     /// let message = UMessageBuilder::request(method_to_invoke, reply_to_address, 5000)
     ///                     .with_token(token.clone())
     ///                     .build_with_payload("lock", UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
-    /// assert_eq!(message.attributes.token, Some(token));
+    /// assert_eq!(message.attributes().token, Some(token));
     /// # Ok(())
     /// # }
     /// ```
@@ -474,7 +470,7 @@ impl UMessageBuilder {
     /// let message = UMessageBuilder::request(method_to_invoke, reply_to_address, 5000)
     ///                     .with_permission_level(12)
     ///                     .build_with_payload("lock", UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
-    /// assert_eq!(message.attributes.permission_level, Some(12));
+    /// assert_eq!(message.attributes().permission_level, Some(12));
     /// # Ok(())
     /// # }
     /// ```
@@ -514,7 +510,7 @@ impl UMessageBuilder {
     /// let message = UMessageBuilder::response(reply_to_address, request_msg_id, invoked_method)
     ///                     .with_comm_status(status)
     ///                     .build()?;
-    /// assert_eq!(message.attributes.commstatus, Some(EnumOrUnknown::from_i32(status)));
+    /// assert_eq!(message.attributes().commstatus, Some(EnumOrUnknown::from_i32(status)));
     /// # Ok(())
     /// # }
     /// ```
@@ -522,6 +518,38 @@ impl UMessageBuilder {
         assert!(self.message_type == UMessageType::UMESSAGE_TYPE_RESPONSE);
         self.comm_status = Some(EnumOrUnknown::from_i32(comm_status));
         self
+    }
+
+    fn build_internal(
+        &self,
+        payload: Option<Bytes>,
+        format: Option<UPayloadFormat>,
+    ) -> Result<UMessage, UMessageError> {
+        let message_id = self
+            .message_id
+            .clone()
+            .map_or_else(|| Some(UUIDBuilder::build()), Some);
+        let attributes = UAttributes {
+            id: message_id.into(),
+            type_: self.message_type.into(),
+            source: self.source.clone().into(),
+            sink: self.sink.clone().into(),
+            priority: self.priority.into(),
+            ttl: self.ttl,
+            token: self.token.clone(),
+            permission_level: self.permission_level,
+            commstatus: self.comm_status,
+            reqid: self.request_id.clone().into(),
+            payload_format: format.unwrap_or_default().into(),
+            ..Default::default()
+        };
+        self.validator
+            .validate(&attributes)
+            .map_err(UMessageError::from)
+            .map(|_| UMessage {
+                attributes,
+                payload,
+            })
     }
 
     /// Creates the message based on the builder's state.
@@ -574,38 +602,13 @@ impl UMessageBuilder {
     /// let message = UMessageBuilder::response(reply_to_address, UUIDBuilder::build(), invoked_method)
     ///                     .with_message_id(message_id.clone())
     ///                     .build()?;
-    /// assert_eq!(message.attributes.id, Some(message_id).into());
-    /// # assert_eq!(message.attributes.id.clone().unwrap().lsb, lsb);
+    /// assert_eq!(message.attributes().id, Some(message_id).into());
+    /// # assert_eq!(message.attributes().id.clone().unwrap().lsb, lsb);
     /// # Ok(())
     /// # }
     /// ```
     pub fn build(&self) -> Result<UMessage, UMessageError> {
-        let message_id = self
-            .message_id
-            .clone()
-            .map_or_else(|| Some(UUIDBuilder::build()), Some);
-        let attributes = UAttributes {
-            id: message_id.into(),
-            type_: self.message_type.into(),
-            source: self.source.clone().into(),
-            sink: self.sink.clone().into(),
-            priority: self.priority.into(),
-            ttl: self.ttl,
-            token: self.token.clone(),
-            permission_level: self.permission_level,
-            commstatus: self.comm_status,
-            reqid: self.request_id.clone().into(),
-            payload_format: self.payload_format.into(),
-            ..Default::default()
-        };
-        self.validator
-            .validate(&attributes)
-            .map_err(UMessageError::from)
-            .map(|_| UMessage {
-                attributes: Some(attributes).into(),
-                payload: self.payload.to_owned(),
-                ..Default::default()
-            })
+        self.build_internal(None, None)
     }
 
     /// Creates the message based on the builder's state and some payload.
@@ -633,7 +636,7 @@ impl UMessageBuilder {
     /// let topic = UUri::try_from("my-vehicle/4210/1/B24D")?;
     /// let message = UMessageBuilder::publish(topic)
     ///                    .build_with_payload("locked", UPayloadFormat::UPAYLOAD_FORMAT_TEXT)?;
-    /// assert!(message.payload.is_some());
+    /// assert!(message.payload().is_some());
     /// # Ok(())
     /// # }
     /// ```
@@ -642,10 +645,7 @@ impl UMessageBuilder {
         payload: T,
         format: UPayloadFormat,
     ) -> Result<UMessage, UMessageError> {
-        self.payload = Some(payload.into());
-        self.payload_format = format;
-
-        self.build()
+        self.build_internal(Some(payload.into()), Some(format))
     }
 
     /// Creates the message based on the builder's state and some payload.
@@ -680,8 +680,8 @@ impl UMessageBuilder {
     /// let message = UMessageBuilder::response(reply_to_address, request_id, invoked_method)
     ///                    .with_comm_status(UCode::INVALID_ARGUMENT.value())
     ///                    .build_with_protobuf_payload(&UStatus::fail("failed to parse request"))?;
-    /// assert!(message.payload.is_some());
-    /// assert_eq!(message.attributes.payload_format.enum_value().unwrap(), UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF);
+    /// assert!(message.payload().is_some());
+    /// assert_eq!(message.attributes().payload_format.enum_value().unwrap(), UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF);
     /// # Ok(())
     /// # }
     /// ```
@@ -732,8 +732,8 @@ impl UMessageBuilder {
     /// let message = UMessageBuilder::response(reply_to_address, request_id, invoked_method)
     ///                    .with_comm_status(UCode::INVALID_ARGUMENT.value())
     ///                    .build_with_wrapped_protobuf_payload(&UStatus::fail("failed to parse request"))?;
-    /// assert!(message.payload.is_some());
-    /// assert_eq!(message.attributes.payload_format.enum_value().unwrap(), UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY);
+    /// assert!(message.payload().is_some());
+    /// assert_eq!(message.attributes().payload_format.enum_value().unwrap(), UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY);
     /// # Ok(())
     /// # }
     /// ```

--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -43,7 +43,7 @@ use crate::{UMessage, UStatus, UUri};
 /// impl UListener for FooListener {
 ///     async fn on_receive(&self, msg: UMessage) {
 ///         let mut inner_foo = self.inner_foo.lock().unwrap();
-///         if let Some(payload) = msg.payload.as_ref() {
+///         if let Some(payload) = msg.payload() {
 ///             *inner_foo = format!("latest message length: {}", payload.len());
 ///         }
 ///     }
@@ -68,7 +68,7 @@ use crate::{UMessage, UStatus, UUri};
 ///
 /// async fn send_to_jupiter(message_for_jupiter: UMessage) {
 ///     // send a message to Jupiter
-///     println!("Fly me to the moon... {message_for_jupiter}");
+///     println!("Fly me to the moon... {:?}", message_for_jupiter);
 /// }
 ///
 /// #[async_trait]
@@ -341,6 +341,7 @@ impl Eq for ComparableListener {}
 mod tests {
     use crate::ComparableListener;
     use crate::UListener;
+    use crate::UMessageBuilder;
     use crate::{UCode, UMessage, UStatus, UTransport, UUri};
     use async_std::task;
     use async_trait::async_trait;
@@ -492,6 +493,17 @@ mod tests {
         }
     }
 
+    fn publish_message() -> UMessage {
+        UMessageBuilder::publish(UUri {
+            ue_id: 0x0001,
+            ue_version_major: 0x01,
+            resource_id: 0xabcd,
+            ..Default::default()
+        })
+        .build()
+        .unwrap()
+    }
+
     #[test]
     fn test_register_and_receive() {
         let mut up_client_foo = UPClientFoo::default();
@@ -501,7 +513,7 @@ mod tests {
             task::block_on(up_client_foo.register_listener(&uuri_1, None, listener_baz.clone()));
         assert!(register_res.is_ok());
 
-        let umessage = UMessage::default();
+        let umessage = publish_message();
         let check_on_receive_res = up_client_foo.check_on_receive(&uuri_1, &umessage);
         assert_eq!(check_on_receive_res, Ok(()));
     }
@@ -515,7 +527,7 @@ mod tests {
             task::block_on(up_client_foo.register_listener(&uuri_1, None, listener_baz.clone()));
         assert!(register_res.is_ok());
 
-        let umessage = UMessage::default();
+        let umessage = publish_message();
         let check_on_receive_res = up_client_foo.check_on_receive(&uuri_1, &umessage);
         assert_eq!(check_on_receive_res, Ok(()));
 
@@ -523,7 +535,7 @@ mod tests {
             task::block_on(up_client_foo.unregister_listener(&uuri_1, None, listener_baz));
         assert!(unregister_res.is_ok());
 
-        let umessage = UMessage::default();
+        let umessage = publish_message();
         let check_on_receive_res = up_client_foo.check_on_receive(&uuri_1, &umessage);
         assert!(check_on_receive_res.is_err());
     }
@@ -543,7 +555,7 @@ mod tests {
             task::block_on(up_client_foo.register_listener(&uuri_1, None, listener_bar.clone()));
         assert!(register_res.is_ok());
 
-        let umessage = UMessage::default();
+        let umessage = publish_message();
         let check_on_receive_res = up_client_foo.check_on_receive(&uuri_1, &umessage);
         assert_eq!(check_on_receive_res, Ok(()));
 
@@ -563,7 +575,7 @@ mod tests {
         let mut up_client_foo = UPClientFoo::default();
         let uuri_1 = uuri_factory(1);
 
-        let umessage = UMessage::default();
+        let umessage = publish_message();
         let check_on_receive_res = up_client_foo.check_on_receive(&uuri_1, &umessage);
 
         assert!(check_on_receive_res.is_err());
@@ -591,7 +603,7 @@ mod tests {
         ));
         assert!(register_res.is_ok());
 
-        let umessage = UMessage::default();
+        let umessage = publish_message();
         let check_on_receive_res = up_client_foo.check_on_receive(&uuri_1, &umessage);
         assert_eq!(check_on_receive_res, Ok(()));
 


### PR DESCRIPTION
The build.rs script no longer pulls in the umessage.proto from up-spec.
Instead, the umessage module no defines the UMessage struct with
private fields so that UMessages can now only be created (correctly) via
the UMessageBuilder.