### PR TITLE
Add missing usubscription type export, minor qol functions

### DIFF
--- a/src/communication.rs
+++ b/src/communication.rs
@@ -13,11 +13,15 @@
 
 use bytes::Bytes;
 pub use notification::{NotificationError, NotificationListener, Notifier};
+use protobuf::Message;
 pub use pubsub::{PubSubError, Publisher, Subscriber};
 pub use rpc::{RpcClient, RpcServer, ServiceInvocationError};
 use std::{error::Error, fmt::Display};
 
-use crate::{UPayloadFormat, UPriority};
+use crate::{
+    umessage::{self, UMessageError},
+    UPayloadFormat, UPriority,
+};
 
 mod notification;
 mod pubsub;
@@ -54,12 +58,12 @@ impl Display for RegistrationError {
 
 impl Error for RegistrationError {}
 
-const DEFAULT_TTL: u16 = 10_000; // 10 seconds
+const DEFAULT_TTL: u32 = 10_000; // 10 seconds
 
 /// General options that clients might want to specify when sending a uProtocol message.
 #[derive(Debug)]
 pub struct CallOptions {
-    ttl: u16,
+    ttl: u32,
     token: Option<String>,
     priority: Option<UPriority>,
 }
@@ -76,24 +80,90 @@ impl Default for CallOptions {
 }
 
 impl CallOptions {
-    pub fn with_ttl(&mut self, ttl: u16) -> &mut Self {
+    /// Creates a new `CallOption`` with the desired ttl value.
+    ///
+    /// # Arguments
+    ///
+    /// * `ttl` - The time-to-live parameter.
+    /// * `token` - Optional token.
+    /// * `priority` - Optional priority.
+    ///
+    /// # Returns
+    ///
+    /// `CallOption` with specified ttl value, token and priority parameters.
+    pub fn new(ttl: u32, token: Option<String>, priority: Option<UPriority>) -> Self {
+        CallOptions {
+            ttl,
+            token,
+            priority,
+        }
+    }
+
+    /// Sets `CallOption` ttl value.
+    ///
+    /// # Arguments
+    ///
+    /// * `ttl` - The time-to-live parameter.
+    ///
+    /// # Returns
+    ///
+    /// `CallOption` with specified ttl value.
+    pub fn with_ttl(&mut self, ttl: u32) -> &mut Self {
         self.ttl = ttl;
         self
     }
-    pub fn ttl(&self) -> u16 {
+
+    /// Returns `CallOption` ttl value.
+    ///
+    /// # Returns
+    ///
+    /// ttl value of `CallOption`.
+    pub fn ttl(&self) -> u32 {
         self.ttl
     }
+
+    /// Sets `CallOption` token value.
+    ///
+    /// # Arguments
+    ///
+    /// * `token` - The token parameter.
+    ///
+    /// # Returns
+    ///
+    /// `CallOption` with specified token value.
     pub fn with_token(&mut self, token: String) -> &mut Self {
         self.token = Some(token);
         self
     }
+
+    /// Returns `CallOption` token value.
+    ///
+    /// # Returns
+    ///
+    /// token value of `CallOption`.
     pub fn token(&self) -> Option<String> {
         self.token.clone()
     }
+
+    /// Sets `CallOption` priority value.
+    ///
+    /// # Arguments
+    ///
+    /// * `priority` - The priority parameter.
+    ///
+    /// # Returns
+    ///
+    /// `CallOption` with specified priority value.
     pub fn with_priority(&mut self, priority: UPriority) -> &mut Self {
         self.priority = Some(priority);
         self
     }
+
+    /// Returns `CallOption` priority value.
+    ///
+    /// # Returns
+    ///
+    /// priority value of `CallOption`.
     pub fn priority(&self) -> Option<UPriority> {
         self.priority
     }
@@ -114,13 +184,65 @@ impl UPayload {
         }
     }
 
+    /// Creates a new UPayload from a protobuf `Message`, will set payload
+    /// type to `UPayload::UPAYLOAD_FORMAT_PROTOBUF`.
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - The protobuf `Message` to wrap in UPayload.
+    ///
+    /// # Returns
+    ///
+    /// `UPayload` serialized from `Message` with as `UPayloadType::UPAYLOAD_FORMAT_PROTOBUF` payload,
+    /// `UMessageError::DataSerializationError` in case the conversion failed.
+    pub fn try_from_protobuf<M>(message: M) -> Result<Self, UMessageError>
+    where
+        M: Message,
+    {
+        match message.write_to_bytes() {
+            Ok(bytes) => Ok(UPayload::new(
+                bytes.into(),
+                UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF,
+            )),
+            Err(e) => Err(UMessageError::DataSerializationError(e)),
+        }
+    }
+
+    /// Gets the payload format.
+    ///
+    /// # Returns
+    ///
+    /// payload value of `UPayload`.
     pub fn payload_format(&self) -> UPayloadFormat {
         self.payload_format
     }
+
     /// Gets the payload data.
     ///
     /// Note that this consumes the payload.
     pub fn payload(self) -> Bytes {
         self.payload
+    }
+
+    /// Extracts the protobuf `Message` contained in payload.
+    ///
+    /// This function is used to extract strongly-typed data from a `UPayload` object,
+    /// taking into account the payload format (will only succeed if payload format is
+    /// `UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF` or `UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY`)
+    ///
+    /// # Type Parameters
+    ///
+    /// * `T`: The target type of the data to be unpacked.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(T)`: The deserialized protobuf `Message` contained in the payload.
+    ///
+    /// # Errors
+    ///
+    /// * Err(`UMessageError`) if the unpacking process fails, for example if the payload could
+    /// not be deserialized into the target type `T`.
+    pub fn extract_protobuf<T: Message + Default>(&self) -> Result<T, UMessageError> {
+        umessage::deserialize_protobuf_bytes(&self.payload, &self.payload_format)
     }
 }

--- a/src/core/usubscription.rs
+++ b/src/core/usubscription.rs
@@ -15,7 +15,7 @@ pub use crate::up_core_api::usubscription::{
     subscription_status::State, EventDeliveryConfig, FetchSubscribersRequest,
     FetchSubscribersResponse, FetchSubscriptionsRequest, FetchSubscriptionsResponse,
     NotificationsRequest, SubscribeAttributes, SubscriberInfo, Subscription, SubscriptionRequest,
-    SubscriptionResponse, SubscriptionStatus, UnsubscribeRequest, Update,
+    SubscriptionResponse, SubscriptionStatus, UnsubscribeRequest, UnsubscribeResponse, Update,
 };
 
 use crate::UStatus;
@@ -29,6 +29,17 @@ impl Hash for SubscriberInfo {
 }
 
 impl Eq for SubscriberInfo {}
+
+/// Check if `SubscriberInfo` is empty by comparing with `SubscriberInfo::default()` object.
+///
+/// # Returns
+///
+/// 'true' if `SubscriberInfo` is equal to `SubscriberInfo::default()`, `false` otherwise.
+impl SubscriberInfo {
+    pub fn is_empty(&self) -> bool {
+        self.eq(&SubscriberInfo::default())
+    }
+}
 
 /// `USubscription` is the uP-L3 client interface to the uSubscription service.
 ///

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -274,6 +274,15 @@ impl Hash for UUri {
 impl Eq for UUri {}
 
 impl UUri {
+    /// Check if `UUri` is empty by comparing with `UUri::default()` object.
+    ///
+    /// # Returns
+    ///
+    /// 'true' if `UUri` is equal to `UUri::default()`, `false` otherwise.
+    pub fn is_empty(&self) -> bool {
+        self.eq(&UUri::default())
+    }
+
     /// Serializes this UUri to a URI string.
     ///
     /// # Arguments


### PR DESCRIPTION
Minor items:
- Missing export of UnsubscribeResponse type in usubscription module
- is_empty() checks for UUri and SusbcriberInfo types (will compare with ::default() objects)