### PR TITLE
Add UTransport based RpcClient implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+
+[[package]]
 name = "anyhow"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +229,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futures-channel"
@@ -564,6 +582,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +759,32 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "predicates"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1122,6 +1193,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
 name = "test-case"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,18 +1233,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1324,6 +1401,7 @@ dependencies = [
  "bytes",
  "chrono",
  "mediatype",
+ "mockall",
  "once_cell",
  "protobuf",
  "protobuf-codegen",
@@ -1332,7 +1410,9 @@ dependencies = [
  "regex",
  "reqwest",
  "test-case",
+ "thiserror",
  "tokio",
+ "tracing",
  "uriparse",
  "uuid-simd",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,161 +48,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
-dependencies = [
- "concurrent-queue",
- "event-listener 5.2.0",
- "event-listener-strategy 0.5.1",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b3e585719c2358d2660232671ca8ca4ddb4be4ce8a1842d6c2dc8685303316"
-dependencies = [
- "async-lock 3.3.0",
- "async-task",
- "concurrent-queue",
- "fastrand 2.0.2",
- "futures-lite 2.3.0",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.2.0",
- "async-executor",
- "async-io 2.3.2",
- "async-lock 3.3.0",
- "blocking",
- "futures-lite 2.3.0",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
-dependencies = [
- "async-lock 2.8.0",
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-lite 1.13.0",
- "log",
- "parking",
- "polling 2.8.0",
- "rustix 0.37.27",
- "slab",
- "socket2 0.4.10",
- "waker-fn",
-]
-
-[[package]]
-name = "async-io"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884"
-dependencies = [
- "async-lock 3.3.0",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite 2.3.0",
- "parking",
- "polling 3.6.0",
- "rustix 0.38.32",
- "slab",
- "tracing",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
-dependencies = [
- "event-listener 4.0.3",
- "event-listener-strategy 0.4.0",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-std"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
-dependencies = [
- "async-attributes",
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io 1.13.0",
- "async-lock 2.8.0",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite 1.13.0",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
-
-[[package]]
 name = "async-trait"
 version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,14 +55,8 @@ checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -259,22 +98,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
-name = "blocking"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
-dependencies = [
- "async-channel 2.2.0",
- "async-lock 3.3.0",
- "async-task",
- "fastrand 2.0.2",
- "futures-io",
- "futures-lite 2.3.0",
- "piper",
- "tracing",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,15 +136,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,12 +150,6 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "either"
@@ -372,63 +180,6 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
-dependencies = [
- "event-listener 4.0.3",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332f51cb23d20b0de8458b86580878211da09bcd4503cb579c225b3d124cabb3"
-dependencies = [
- "event-listener 5.2.0",
- "pin-project-lite",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
 ]
 
 [[package]]
@@ -468,21 +219,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,60 +235,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
-
-[[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
-dependencies = [
- "fastrand 2.0.2",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "futures-macro"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.58",
-]
 
 [[package]]
 name = "futures-sink"
@@ -572,10 +258,8 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -600,18 +284,6 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "h2"
@@ -748,7 +420,7 @@ dependencies = [
  "http-body",
  "hyper",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2",
  "tokio",
  "tower",
  "tower-service",
@@ -809,26 +481,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,15 +502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,12 +515,6 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
@@ -887,9 +524,6 @@ name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "mediatype"
@@ -1004,7 +638,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -1032,12 +666,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
 
 [[package]]
-name = "parking"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,7 +688,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -1076,52 +704,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
-dependencies = [
- "atomic-waker",
- "fastrand 2.0.2",
- "futures-io",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "polling"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "polling"
-version = "3.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c976a60b2d7e99d6f229e414670a9b85d13ac305cc6d1e9c134de58c5aaaf6"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix 0.38.32",
- "tracing",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -1359,20 +945,6 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.37.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
@@ -1380,7 +952,7 @@ dependencies = [
  "bitflags 2.5.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.13",
+ "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
 
@@ -1448,7 +1020,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -1491,33 +1063,12 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]
@@ -1565,8 +1116,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.2",
- "rustix 0.38.32",
+ "fastrand",
+ "rustix",
  "windows-sys 0.52.0",
 ]
 
@@ -1588,7 +1139,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -1599,7 +1150,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
  "test-case-core",
 ]
 
@@ -1620,7 +1171,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -1650,8 +1201,20 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2",
+ "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1757,11 +1320,9 @@ dependencies = [
 name = "up-rust"
 version = "0.1.5"
 dependencies = [
- "async-std",
  "async-trait",
  "bytes",
  "chrono",
- "futures",
  "mediatype",
  "once_cell",
  "protobuf",
@@ -1771,6 +1332,7 @@ dependencies = [
  "regex",
  "reqwest",
  "test-case",
+ "tokio",
  "uriparse",
  "uuid-simd",
 ]
@@ -1807,12 +1369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "value-bag"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74797339c3b98616c009c7c3eb53a0ce41e85c8ec66bd3db96ed132d20cfdee8"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,12 +1379,6 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
-
-[[package]]
-name = "waker-fn"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "want"
@@ -1866,7 +1416,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1900,7 +1450,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1930,30 +1480,8 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.32",
+ "rustix",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,13 @@ once_cell = { version = "1.19" }
 protobuf = { version = "3.3", features = ["with-bytes"] }
 rand = { version = "0.8" }
 regex = { version = "1.10" }
+tokio = { version = "1.35", default-features = false, features = [
+    "macros",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 uriparse = { version = "0.6" }
 uuid-simd = { version = "0.8", default-features = false, features = [
     "std",
@@ -59,8 +66,6 @@ protoc-bin-vendored = { version = "3.0" }
 reqwest = { version = "0.12", features = ["blocking"] }
 
 [dev-dependencies]
-async-std = { version = "1.12.0", features = ["attributes"] }
-futures = { version = "0.3.30" }
 test-case = { version = "3.3" }
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,12 +47,17 @@ once_cell = { version = "1.19" }
 protobuf = { version = "3.3", features = ["with-bytes"] }
 rand = { version = "0.8" }
 regex = { version = "1.10" }
+thiserror = { version = "1.0.52" }
 tokio = { version = "1.35", default-features = false, features = [
     "macros",
     "rt",
     "rt-multi-thread",
     "sync",
     "time",
+] }
+tracing = { version = "0.1.35", default-features = false, features = [
+    "log",
+    "std",
 ] }
 uriparse = { version = "0.6" }
 uuid-simd = { version = "0.8", default-features = false, features = [
@@ -66,6 +71,7 @@ protoc-bin-vendored = { version = "3.0" }
 reqwest = { version = "0.12", features = ["blocking"] }
 
 [dev-dependencies]
+mockall = "0.12.1"
 test-case = { version = "3.3" }
 
 [profile.release]

--- a/src/communication.rs
+++ b/src/communication.rs
@@ -12,6 +12,7 @@
  ********************************************************************************/
 
 use bytes::Bytes;
+pub use in_memory_rpc_client::InMemoryRpcClient;
 pub use notification::{NotificationError, NotificationListener, Notifier};
 use protobuf::Message;
 pub use pubsub::{PubSubError, Publisher, Subscriber};
@@ -23,6 +24,7 @@ use crate::{
     UPayloadFormat, UPriority, UUID,
 };
 
+mod in_memory_rpc_client;
 mod notification;
 mod pubsub;
 mod rpc;

--- a/src/communication/in_memory_rpc_client.rs
+++ b/src/communication/in_memory_rpc_client.rs
@@ -1,0 +1,515 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::sync::oneshot::{Receiver, Sender};
+use tracing::{debug, info};
+
+use crate::{
+    LocalUriProvider, UCode, UListener, UMessage, UMessageBuilder, UMessageType, UStatus,
+    UTransport, UUri, UUID,
+};
+
+use super::{CallOptions, RpcClient, ServiceInvocationError, UPayload};
+
+fn handle_response_message(response: UMessage) -> Result<Option<UPayload>, ServiceInvocationError> {
+    let Some(attribs) = response.attributes.as_ref() else {
+        return Err(ServiceInvocationError::RpcError(UStatus::fail_with_code(
+            UCode::INTERNAL,
+            "response message does not contain attributes",
+        )));
+    };
+
+    match attribs.commstatus.map(|v| v.enum_value_or_default()) {
+        Some(UCode::OK) | None => {
+            // successful invocation
+            response.payload.map_or(Ok(None), |payload| {
+                Ok(Some(UPayload::new(
+                    payload,
+                    attribs.payload_format.enum_value_or_default(),
+                )))
+            })
+        }
+        Some(code) => {
+            // try to extract UStatus from response payload
+            let status = response.extract_protobuf().unwrap_or_else(|_e| {
+                UStatus::fail_with_code(code, "failed to invoke service operation")
+            });
+            Err(ServiceInvocationError::from(status))
+        }
+    }
+}
+
+struct ResponseListener {
+    // request ID -> sender for response message
+    pending_requests: Mutex<HashMap<UUID, Sender<UMessage>>>,
+}
+
+impl ResponseListener {
+    fn try_add_pending_request(
+        &self,
+        reqid: UUID,
+    ) -> Result<Receiver<UMessage>, ServiceInvocationError> {
+        let Ok(mut pending_requests) = self.pending_requests.lock() else {
+            return Err(ServiceInvocationError::Internal(
+                "failed to add response handler".to_string(),
+            ));
+        };
+
+        if let Entry::Vacant(entry) = pending_requests.entry(reqid) {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            entry.insert(tx);
+            Ok(rx)
+        } else {
+            Err(ServiceInvocationError::AlreadyExists(
+                "RPC request with given ID already pending".to_string(),
+            ))
+        }
+    }
+
+    fn handle_response(&self, reqid: &UUID, response_message: UMessage) {
+        let Ok(mut pending_requests) = self.pending_requests.lock() else {
+            info!(
+                request_id = reqid.to_hyphenated_string(),
+                "failed to process response message, cannot acquire lock for pending requests map"
+            );
+            return;
+        };
+        if let Some(sender) = pending_requests.remove(reqid) {
+            if let Err(_e) = sender.send(response_message) {
+                // channel seems to be closed already
+                debug!(
+                    request_id = reqid.to_hyphenated_string(),
+                    "failed to deliver response message, channel already closed"
+                );
+            }
+        } else {
+            // we seem to have received a duplicate of the response message, ignoring it ...
+            debug!(
+                request_id = reqid.to_hyphenated_string(),
+                "ignoring response message for unknown request"
+            );
+        }
+    }
+
+    fn remove_pending_request(&self, reqid: &UUID) -> Option<Sender<UMessage>> {
+        self.pending_requests
+            .lock()
+            .map_or(None, |mut pending_requests| pending_requests.remove(reqid))
+    }
+
+    #[cfg(test)]
+    fn contains(&self, reqid: &UUID) -> bool {
+        self.pending_requests
+            .lock()
+            .map_or(false, |pending_requests| {
+                pending_requests.contains_key(reqid)
+            })
+    }
+}
+
+#[async_trait]
+impl UListener for ResponseListener {
+    async fn on_receive(&self, msg: UMessage) {
+        let message_type = msg
+            .attributes
+            .get_or_default()
+            .type_
+            .enum_value_or_default();
+        if message_type != UMessageType::UMESSAGE_TYPE_RESPONSE {
+            debug!(
+                message_type = message_type.to_cloudevent_type(),
+                "service provider replied with message that is not an RPC Response"
+            );
+            return;
+        }
+
+        if let Some(reqid) = msg
+            .attributes
+            .as_ref()
+            .and_then(|attribs| attribs.reqid.clone().into_option())
+        {
+            self.handle_response(&reqid, msg);
+        } else {
+            debug!("ignoring malformed response message not containing request ID");
+        }
+    }
+}
+
+/// An ['RpcClient'] which keeps all information about pending requests in memory.
+pub struct InMemoryRpcClient {
+    transport: Arc<dyn UTransport>,
+    uri_provider: Arc<dyn LocalUriProvider>,
+    response_listener: Arc<ResponseListener>,
+}
+
+impl InMemoryRpcClient {
+    /// Creates a new RPC client for a given transport.
+    ///
+    /// # Arguments
+    ///
+    /// * `transport` - The uProtocol Transport Layer implementation to use for invoking service operations.
+    /// * `uri_provider` - The helper for creating URIs that represent local resources.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the generic RPC Response listener could not be
+    /// registered with the given transport.
+    pub async fn new(
+        transport: Arc<dyn UTransport>,
+        uri_provider: Arc<dyn LocalUriProvider>,
+    ) -> Result<Self, UStatus> {
+        let response_listener = Arc::new(ResponseListener {
+            pending_requests: Mutex::new(HashMap::new()),
+        });
+        transport
+            .register_listener(
+                &UUri::any(),
+                Some(&uri_provider.get_source_uri()),
+                response_listener.clone(),
+            )
+            .await?;
+
+        Ok(InMemoryRpcClient {
+            transport,
+            uri_provider,
+            response_listener,
+        })
+    }
+
+    #[cfg(test)]
+    fn contains_pending_request(&self, reqid: &UUID) -> bool {
+        self.response_listener.contains(reqid)
+    }
+}
+
+#[async_trait]
+impl RpcClient for InMemoryRpcClient {
+    async fn invoke_method(
+        &self,
+        method: UUri,
+        call_options: CallOptions,
+        payload: Option<UPayload>,
+    ) -> Result<Option<UPayload>, ServiceInvocationError> {
+        let message_id = call_options.message_id().unwrap_or_else(UUID::build);
+
+        let mut builder = UMessageBuilder::request(
+            method.clone(),
+            self.uri_provider.get_source_uri(),
+            call_options.ttl(),
+        );
+        builder.with_message_id(message_id.clone());
+        if let Some(token) = call_options.token() {
+            builder.with_token(token.to_owned());
+        }
+        if let Some(priority) = call_options.priority() {
+            builder.with_priority(priority);
+        }
+        if let Some(traceparent) = call_options.traceparent() {
+            builder.with_traceparent(traceparent);
+        }
+        let rpc_request_message = if let Some(pl) = payload {
+            let format = pl.payload_format();
+            builder.build_with_payload(pl.payload(), format)
+        } else {
+            builder.build()
+        }
+        .map_err(|e| ServiceInvocationError::InvalidArgument(e.to_string()))?;
+
+        let receiver = self
+            .response_listener
+            .try_add_pending_request(message_id.clone())?;
+        self.transport
+            .send(rpc_request_message)
+            .await
+            .map_err(|e| {
+                self.response_listener.remove_pending_request(&message_id);
+                e
+            })?;
+
+        if let Ok(Ok(response_message)) =
+            tokio::time::timeout(Duration::from_millis(call_options.ttl() as u64), receiver).await
+        {
+            handle_response_message(response_message)
+        } else {
+            self.response_listener.remove_pending_request(&message_id);
+            Err(ServiceInvocationError::DeadlineExceeded)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    use mockall::mock;
+    use protobuf::{well_known_types::wrappers::StringValue, Enum};
+
+    use crate::{UMessageBuilder, UPriority, UUri};
+
+    mock! {
+        pub UriLocator {}
+        impl LocalUriProvider for UriLocator {
+            fn get_authority(&self) -> String;
+            fn get_resource_uri(&self, resource_id: u16) -> UUri;
+            fn get_source_uri(&self) -> UUri;
+        }
+    }
+
+    mock! {
+        pub Transport {
+            async fn do_send(&self, message: UMessage) -> Result<(), UStatus>;
+            async fn do_register_listener<'a>(&'a self, source_filter: &'a UUri, sink_filter: Option<&'a UUri>, listener: Arc<dyn UListener>) -> Result<(), UStatus>;
+            async fn do_unregister_listener<'a>(&'a self, source_filter: &'a UUri, sink_filter: Option<&'a UUri>, listener: Arc<dyn UListener>) -> Result<(), UStatus>;
+        }
+    }
+
+    #[async_trait]
+    impl UTransport for MockTransport {
+        async fn send(&self, message: UMessage) -> Result<(), UStatus> {
+            self.do_send(message).await
+        }
+        async fn register_listener(
+            &self,
+            source_filter: &UUri,
+            sink_filter: Option<&UUri>,
+            listener: Arc<dyn UListener>,
+        ) -> Result<(), UStatus> {
+            self.do_register_listener(source_filter, sink_filter, listener)
+                .await
+        }
+        async fn unregister_listener(
+            &self,
+            source_filter: &UUri,
+            sink_filter: Option<&UUri>,
+            listener: Arc<dyn UListener>,
+        ) -> Result<(), UStatus> {
+            self.do_unregister_listener(source_filter, sink_filter, listener)
+                .await
+        }
+    }
+
+    fn new_uri_provider() -> Arc<dyn LocalUriProvider> {
+        let mut mock_uri_locator = MockUriLocator::new();
+        mock_uri_locator.expect_get_source_uri().returning(|| UUri {
+            ue_id: 0x0005,
+            ue_version_major: 0x02,
+            resource_id: 0x0000,
+            ..Default::default()
+        });
+        Arc::new(mock_uri_locator)
+    }
+
+    fn service_method_uri() -> UUri {
+        UUri {
+            ue_id: 0x0001,
+            ue_version_major: 0x01,
+            resource_id: 0x1000,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_invoke_method_fails_with_transport_error() {
+        // GIVEN an RPC client
+        let mut mock_transport = MockTransport::default();
+        mock_transport
+            .expect_do_register_listener()
+            .once()
+            .returning(|_source_filter, _sink_filter, _listener| Ok(()));
+        // with a transport that fails with an error when invoking a method
+        mock_transport
+            .expect_do_send()
+            .returning(|_request_message| {
+                Err(UStatus::fail_with_code(
+                    UCode::UNAVAILABLE,
+                    "transport not available",
+                ))
+            });
+        let client = InMemoryRpcClient::new(Arc::new(mock_transport), new_uri_provider())
+            .await
+            .unwrap();
+
+        // WHEN invoking a remote service operation
+        let message_id = UUID::build();
+        let mut call_options = CallOptions::default();
+        call_options.with_message_id(message_id.clone());
+        let response = client
+            .invoke_method(service_method_uri(), call_options, None)
+            .await;
+
+        // THEN the invocation fails with the error caused at the Transport Layer
+        assert!(response.is_err_and(|e| matches!(e, ServiceInvocationError::Unavailable(_msg))));
+        assert!(!client.contains_pending_request(&message_id));
+    }
+
+    #[tokio::test]
+    async fn test_invoke_method_succeeds() {
+        let message_id = UUID::build();
+        let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let mut call_options = CallOptions::default();
+        call_options
+            .with_message_id(message_id.clone())
+            .with_priority(crate::UPriority::UPRIORITY_CS6)
+            .with_ttl(5_000)
+            .with_token("my_token")
+            .with_traceparent(traceparent);
+
+        // GIVEN an RPC client
+        let listener_ref: Arc<Mutex<Option<Arc<dyn UListener>>>> = Arc::new(Mutex::new(None));
+        let response_listener = listener_ref.clone();
+
+        let mut mock_transport = MockTransport::default();
+        mock_transport.expect_do_register_listener().returning(
+            move |_source_filter, _sink_filter, listener| {
+                let mut v = listener_ref.lock().unwrap();
+                *v = Some(listener);
+                Ok(())
+            },
+        );
+        let expected_message_id = message_id.clone();
+        mock_transport
+            .expect_do_send()
+            .withf(move |request_message| {
+                request_message
+                    .attributes
+                    .as_ref()
+                    .map_or(false, |attribs| {
+                        attribs.id.as_ref() == Some(&expected_message_id)
+                            && attribs.priority.value() == UPriority::UPRIORITY_CS6.value()
+                            && attribs.ttl == Some(5_000)
+                            && attribs.token == Some("my_token".to_string())
+                            && attribs.traceparent == Some(traceparent.to_string())
+                    })
+            })
+            .returning(move |request_message| {
+                let request_payload: StringValue = request_message.extract_protobuf().unwrap();
+                let response_payload = StringValue {
+                    value: format!("Hello {}", request_payload.value),
+                    ..Default::default()
+                };
+
+                let response_message = UMessageBuilder::response_for_request(
+                    request_message.attributes.as_ref().unwrap(),
+                )
+                .build_with_protobuf_payload(&response_payload)
+                .unwrap();
+                let cloned_listener = response_listener.lock().unwrap().take().unwrap().clone();
+                tokio::spawn(async move { cloned_listener.on_receive(response_message).await });
+                Ok(())
+            });
+
+        let rpc_client = Arc::new(
+            InMemoryRpcClient::new(Arc::new(mock_transport), new_uri_provider())
+                .await
+                .unwrap(),
+        );
+        let client: Arc<dyn RpcClient> = rpc_client.clone();
+
+        // WHEN invoking a remote service operation
+        let request_payload = StringValue {
+            value: "World".to_string(),
+            ..Default::default()
+        };
+        let response: StringValue = client
+            .invoke_proto_method(service_method_uri(), call_options, request_payload)
+            .await
+            .expect("invoking method should have succeeded");
+        // THEN the response contains the expected payload
+        assert_eq!(response.value, "Hello World");
+        assert!(!rpc_client.contains_pending_request(&message_id));
+    }
+
+    #[tokio::test]
+    async fn test_invoke_method_fails_with_remote_error() {
+        // GIVEN an RPC client
+        let listener_ref: Arc<Mutex<Option<Arc<dyn UListener>>>> = Arc::new(Mutex::new(None));
+        let response_listener = listener_ref.clone();
+
+        let mut mock_transport = MockTransport::default();
+        mock_transport.expect_do_register_listener().returning(
+            move |_source_filter, _sink_filter, listener| {
+                let mut v = listener_ref.lock().unwrap();
+                *v = Some(listener);
+                Ok(())
+            },
+        );
+        // and a remote service operation that returns an error
+        mock_transport
+            .expect_do_send()
+            .returning(move |request_message| {
+                let error = UStatus::fail_with_code(UCode::NOT_FOUND, "no such object");
+                let response_message = UMessageBuilder::response_for_request(
+                    request_message.attributes.as_ref().unwrap(),
+                )
+                .with_comm_status(UCode::NOT_FOUND)
+                .build_with_protobuf_payload(&error)
+                .unwrap();
+                let cloned_listener = response_listener.lock().unwrap().take().unwrap().clone();
+                tokio::spawn(async move { cloned_listener.on_receive(response_message).await });
+                Ok(())
+            });
+
+        let client = InMemoryRpcClient::new(Arc::new(mock_transport), new_uri_provider())
+            .await
+            .unwrap();
+
+        // WHEN invoking the remote service operation
+        let message_id = UUID::build();
+        let mut call_options = CallOptions::default();
+        call_options.with_message_id(message_id.clone());
+        let response = client
+            .invoke_method(service_method_uri(), CallOptions::default(), None)
+            .await;
+
+        // THEN the invocation has failed with the error returned from the service
+        assert!(response.is_err_and(|e| { matches!(e, ServiceInvocationError::NotFound(_msg)) }));
+        assert!(!client.contains_pending_request(&message_id));
+    }
+
+    #[tokio::test]
+    async fn test_invoke_method_times_out() {
+        // GIVEN an RPC client
+        let mut mock_transport = MockTransport::default();
+        mock_transport
+            .expect_do_register_listener()
+            .returning(|_source_filter, _sink_filter, _listener| Ok(()));
+        // and a remote service operation that does not return a response
+        mock_transport
+            .expect_do_send()
+            .returning(|_request_message| Ok(()));
+
+        let client = InMemoryRpcClient::new(Arc::new(mock_transport), new_uri_provider())
+            .await
+            .unwrap();
+
+        // WHEN invoking the remote service operation
+        let message_id = UUID::build();
+        let mut call_options = CallOptions::default();
+        call_options.with_ttl(20);
+        call_options.with_message_id(message_id.clone());
+        let response = client
+            .invoke_method(service_method_uri(), call_options, None)
+            .await;
+
+        // THEN the invocation times out
+        assert!(response.is_err_and(|e| { matches!(e, ServiceInvocationError::DeadlineExceeded) }));
+        assert!(!client.contains_pending_request(&message_id));
+    }
+}

--- a/src/core/usubscription.rs
+++ b/src/core/usubscription.rs
@@ -171,7 +171,7 @@ impl SubscriberInfo {
 /// #     }
 /// # }
 /// #
-/// # #[async_std::main]
+/// # #[tokio::main]
 /// # pub async fn main() -> Result<(), UStatus> {
 /// #
 /// # let my_uuri = Default::default();

--- a/src/core/usubscription.rs
+++ b/src/core/usubscription.rs
@@ -163,11 +163,6 @@ impl SubscriberInfo {
 /// #     async fn on_receive(&self, msg: UMessage) {
 /// #         todo!()
 /// #     }
-/// #
-/// #     async fn on_error(&self, err: UStatus) {
-/// #         todo!()
-/// #     }
-/// #
 /// # }
 /// #
 /// # impl MyListener {

--- a/src/uattributes.rs
+++ b/src/uattributes.rs
@@ -56,6 +56,20 @@ impl std::fmt::Display for UAttributesError {
 impl std::error::Error for UAttributesError {}
 
 impl UAttributes {
+    /// Checks if these are the attributes for an RPC Request message.
+    pub fn is_request(&self) -> bool {
+        self.type_
+            .enum_value()
+            .map_or(false, |v| v == UMessageType::UMESSAGE_TYPE_REQUEST)
+    }
+
+    /// Checks if these are the attributes for an RPC Response message.
+    pub fn is_response(&self) -> bool {
+        self.type_
+            .enum_value()
+            .map_or(false, |v| v == UMessageType::UMESSAGE_TYPE_RESPONSE)
+    }
+
     /// Creates attributes representing an RPC request message.
     ///
     /// The message's priority will be set to [`UPriority::UPRIORITY_CS4`].

--- a/src/umessage.rs
+++ b/src/umessage.rs
@@ -66,6 +66,16 @@ impl From<&str> for UMessageError {
 }
 
 impl UMessage {
+    /// Checks if this is an RPC Request message.
+    pub fn is_request(&self) -> bool {
+        self.attributes.get_or_default().is_request()
+    }
+
+    /// Checks if this is an RPC Response message.
+    pub fn is_response(&self) -> bool {
+        self.attributes.get_or_default().is_response()
+    }
+
     /// If `UMessage` payload is available, deserialize it as a protobuf `Message`.
     ///
     /// This function is used to extract strongly-typed data from a `UMessage` object,

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -283,6 +283,17 @@ impl UUri {
         self.eq(&UUri::default())
     }
 
+    /// Gets a URI that consists of wildcards only and therefore matches any URI.
+    pub fn any() -> Self {
+        UUri {
+            authority_name: WILDCARD_AUTHORITY.to_string(),
+            ue_id: WILDCARD_ENTITY_ID,
+            ue_version_major: WILDCARD_ENTITY_VERSION,
+            resource_id: WILDCARD_RESOURCE_ID,
+            ..Default::default()
+        }
+    }
+
     /// Serializes this UUri to a URI string.
     ///
     /// # Arguments

--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -61,10 +61,6 @@ pub trait LocalUriProvider: Send + Sync {
 ///             *inner_foo = format!("latest message length: {}", payload.len());
 ///         }
 ///     }
-///
-///     async fn on_error(&self, err: UStatus) {
-///         println!("uh oh, we got an error: {err:?}");
-///     }
 /// }
 /// ```
 ///
@@ -90,10 +86,6 @@ pub trait LocalUriProvider: Send + Sync {
 ///     async fn on_receive(&self, msg: UMessage) {
 ///         task::spawn(send_to_jupiter(msg));
 ///     }
-///
-///     async fn on_error(&self, err: UStatus) {
-///         println!("unable to send to jupiter :( {err:?}");
-///     }
 /// }
 /// ```
 #[async_trait]
@@ -115,24 +107,6 @@ pub trait UListener: Send + Sync {
     /// Because `on_receive()` is async you may choose to either `.await` it in the current context
     /// or spawn it onto a new task and await there to allow current context to immediately continue.
     async fn on_receive(&self, msg: UMessage);
-
-    /// Performs some action on receipt of an error.
-    ///
-    /// # Parameters
-    ///
-    /// * `err` - The error as `UStatus`
-    ///
-    /// # Note for `UListener` implementers
-    ///
-    /// `on_error()` is expected to return almost immediately. If it does not, it could potentially
-    /// block further message receipt. For long-running operations consider passing off received
-    /// error to a different async function to handle it and returning.
-    ///
-    /// # Note for `UTransport` implementers
-    ///
-    /// Because `on_error()` is async you may choose to either `.await` it in the current context
-    /// or spawn it onto a new task and await there to allow current context to immediately continue.
-    async fn on_error(&self, err: UStatus);
 }
 
 /// [`UTransport`] is the uP-L1 interface that provides a common API for uE developers to send and receive messages.
@@ -247,10 +221,6 @@ pub trait UTransport: Send + Sync {
     /// # #[async_trait]
     /// # impl UListener for MyListener {
     /// #     async fn on_receive(&self, msg: UMessage) {
-    /// #         todo!()
-    /// #     }
-    /// #
-    /// #     async fn on_error(&self, err: UStatus) {
     /// #         todo!()
     /// #     }
     /// # }
@@ -498,10 +468,6 @@ mod tests {
         async fn on_receive(&self, msg: UMessage) {
             println!("Printing msg from ListenerBaz! received: {:?}", msg);
         }
-
-        async fn on_error(&self, err: UStatus) {
-            println!("Printing err from ListenerBaz! received {:?}", err)
-        }
     }
 
     #[derive(Clone, Debug)]
@@ -510,10 +476,6 @@ mod tests {
     impl UListener for ListenerBar {
         async fn on_receive(&self, msg: UMessage) {
             println!("Printing msg from ListenerBar! received: {:?}", msg);
-        }
-
-        async fn on_error(&self, err: UStatus) {
-            println!("Printing err from ListenerBar! received: {:?}", err);
         }
     }
 


### PR DESCRIPTION
Added an RpcClient implementation that keeps all state
about pending requests in memory only. Also added
corresponding unit tests.