### PR TITLE
Minor QoL additions to USubscription types

### DIFF
--- a/src/core/usubscription.rs
+++ b/src/core/usubscription.rs
@@ -12,11 +12,11 @@
  ********************************************************************************/
 
 pub use crate::up_core_api::usubscription::{
-    subscription_status::State, EventDeliveryConfig, FetchSubscribersRequest,
-    FetchSubscribersResponse, FetchSubscriptionsRequest, FetchSubscriptionsResponse,
-    NotificationsRequest, NotificationsResponse, SubscribeAttributes, SubscriberInfo, Subscription,
-    SubscriptionRequest, SubscriptionResponse, SubscriptionStatus, UnsubscribeRequest,
-    UnsubscribeResponse, Update,
+    fetch_subscriptions_request::Request, subscription_status::State, EventDeliveryConfig,
+    FetchSubscribersRequest, FetchSubscribersResponse, FetchSubscriptionsRequest,
+    FetchSubscriptionsResponse, NotificationsRequest, NotificationsResponse, SubscribeAttributes,
+    SubscriberInfo, Subscription, SubscriptionRequest, SubscriptionResponse, SubscriptionStatus,
+    UnsubscribeRequest, UnsubscribeResponse, Update,
 };
 
 use crate::UStatus;
@@ -39,6 +39,33 @@ impl Eq for SubscriberInfo {}
 impl SubscriberInfo {
     pub fn is_empty(&self) -> bool {
         self.eq(&SubscriberInfo::default())
+    }
+}
+
+impl SubscriptionResponse {
+    /// Checks if this `SubscriptionResponse` is in a specific state (`usubscription::State``).
+    ///
+    /// Returns `true` if SubscriptionReponse contains a valied SusbcriptionStatus, which has a
+    /// state property that is equal to state passed as argument.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use up_rust::core::usubscription::{SubscriptionResponse, SubscriptionStatus, State};
+    ///
+    /// let subscription_response = SubscriptionResponse {
+    ///     status: Some(SubscriptionStatus {
+    ///         state: State::SUBSCRIBED.into(),
+    ///         ..Default::default()
+    ///         }).into(),
+    ///     ..Default::default()
+    /// };
+    /// assert!(subscription_response.is_state(State::SUBSCRIBED));
+    /// ```
+    pub fn is_state(&self, state: State) -> bool {
+        self.status
+            .as_ref()
+            .is_some_and(|ss| ss.state.enum_value().is_ok_and(|s| s.eq(&state)))
     }
 }
 

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -294,6 +294,28 @@ impl UUri {
         }
     }
 
+    /// Check if an `UUri` is remote, by comparing authority fields.
+    ///
+    /// # Returns
+    ///
+    /// 'true' if other_uri has a different authority than `Self`, `false` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::str::FromStr;
+    /// use up_rust::UUri;
+    ///
+    /// let authority_a = UUri::from_str("up://Authority.A/100A/1/0").unwrap();
+    /// let authority_b = UUri::from_str("up://Authority.B/200B/2/20").unwrap();
+    /// assert!(authority_a.is_remote_authority(&authority_b));
+    /// ````
+    pub fn is_remote_authority(&self, other_uri: &UUri) -> bool {
+        self.authority_name != WILDCARD_AUTHORITY
+            && other_uri.authority_name != WILDCARD_AUTHORITY
+            && self.authority_name != other_uri.authority_name
+    }
+
     /// Serializes this UUri to a URI string.
     ///
     /// # Arguments


### PR DESCRIPTION
Minor: 
- add some missing exports of usubscription types
- quality of life method for checking if an UUri is "remote" (has different authority)
- quality of life method for comparing SubscriptionStatus - states