### PR TITLE
Update MSRV to 1.74

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ license = "Apache-2.0"
 name = "up-rust"
 readme = "README.md"
 repository = "https://github.com/eclipse-uprotocol/up-rust"
-rust-version = "1.72.1"
+rust-version = "1.74.1"
 version = "0.1.5"
 
 [features]


### PR DESCRIPTION
Increased the Minimum Supported Rust Version to accomodate for
requirements of the protobuf crate when using MessageFull instead of
the standard Message trait.

This should fix the nightly build which currently fails due to the
MSRV check.