### PR TITLE
Add RpcClient based implementation of USubscription

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,11 @@ rust-version = "1.74.1"
 version = "0.1.5"
 
 [features]
+default = ["communication"]
+communication = ["usubscription"]
 udiscovery = []
 usubscription = []
 utwin = []
-default = []
 
 [dependencies]
 async-trait = { version = "0.1" }

--- a/src/communication.rs
+++ b/src/communication.rs
@@ -12,14 +12,17 @@
  ********************************************************************************/
 
 use bytes::Bytes;
+use protobuf::{well_known_types::any::Any, Message, MessageFull};
+use std::{error::Error, fmt::Display};
+
 pub use default_notifier::SimpleNotifier;
 pub use in_memory_rpc_client::InMemoryRpcClient;
 pub use in_memory_rpc_server::InMemoryRpcServer;
 pub use notification::{NotificationError, Notifier};
-use protobuf::{well_known_types::any::Any, Message, MessageFull};
 pub use pubsub::{PubSubError, Publisher, Subscriber};
 pub use rpc::{RequestHandler, RpcClient, RpcServer, ServiceInvocationError};
-use std::{error::Error, fmt::Display};
+#[cfg(feature = "usubscription")]
+pub use usubscription_client::RpcClientUSubscription;
 
 use crate::{
     umessage::{self, UMessageError},
@@ -32,6 +35,8 @@ mod in_memory_rpc_server;
 mod notification;
 mod pubsub;
 mod rpc;
+#[cfg(feature = "usubscription")]
+mod usubscription_client;
 
 /// An error indicating a problem with registering or unregistering a message listener.
 #[derive(Debug)]

--- a/src/communication/usubscription_client.rs
+++ b/src/communication/usubscription_client.rs
@@ -1,0 +1,454 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::{
+    core::usubscription::{
+        usubscription_uri, FetchSubscribersRequest, FetchSubscribersResponse,
+        FetchSubscriptionsRequest, FetchSubscriptionsResponse, NotificationsRequest,
+        NotificationsResponse, SubscriptionRequest, SubscriptionResponse, USubscription,
+        UnsubscribeRequest, UnsubscribeResponse, RESOURCE_ID_FETCH_SUBSCRIBERS,
+        RESOURCE_ID_FETCH_SUBSCRIPTIONS, RESOURCE_ID_REGISTER_FOR_NOTIFICATIONS,
+        RESOURCE_ID_SUBSCRIBE, RESOURCE_ID_UNREGISTER_FOR_NOTIFICATIONS, RESOURCE_ID_UNSUBSCRIBE,
+    },
+    UStatus,
+};
+
+use super::{CallOptions, RpcClient};
+
+pub struct RpcClientUSubscription {
+    rpc_client: Arc<dyn RpcClient>,
+}
+
+impl RpcClientUSubscription {
+    pub fn new(rpc_client: Arc<dyn RpcClient>) -> Self {
+        RpcClientUSubscription { rpc_client }
+    }
+
+    fn default_call_options() -> CallOptions {
+        CallOptions::for_rpc_request(5_000, None, None, None)
+    }
+}
+
+#[async_trait]
+impl USubscription for RpcClientUSubscription {
+    async fn subscribe(
+        &self,
+        subscription_request: SubscriptionRequest,
+    ) -> Result<SubscriptionResponse, UStatus> {
+        self.rpc_client
+            .invoke_proto_method::<_, SubscriptionResponse>(
+                usubscription_uri(RESOURCE_ID_SUBSCRIBE),
+                Self::default_call_options(),
+                subscription_request,
+            )
+            .await
+            .map_err(UStatus::from)
+    }
+
+    async fn unsubscribe(&self, unsubscribe_request: UnsubscribeRequest) -> Result<(), UStatus> {
+        self.rpc_client
+            .invoke_proto_method::<_, UnsubscribeResponse>(
+                usubscription_uri(RESOURCE_ID_UNSUBSCRIBE),
+                Self::default_call_options(),
+                unsubscribe_request,
+            )
+            .await
+            .map(|_response| ())
+            .map_err(UStatus::from)
+    }
+
+    async fn fetch_subscriptions(
+        &self,
+        fetch_subscriptions_request: FetchSubscriptionsRequest,
+    ) -> Result<FetchSubscriptionsResponse, UStatus> {
+        self.rpc_client
+            .invoke_proto_method::<_, FetchSubscriptionsResponse>(
+                usubscription_uri(RESOURCE_ID_FETCH_SUBSCRIPTIONS),
+                Self::default_call_options(),
+                fetch_subscriptions_request,
+            )
+            .await
+            .map_err(UStatus::from)
+    }
+
+    async fn register_for_notifications(
+        &self,
+        notifications_register_request: NotificationsRequest,
+    ) -> Result<(), UStatus> {
+        self.rpc_client
+            .invoke_proto_method::<_, NotificationsResponse>(
+                usubscription_uri(RESOURCE_ID_REGISTER_FOR_NOTIFICATIONS),
+                Self::default_call_options(),
+                notifications_register_request,
+            )
+            .await
+            .map(|_response| ())
+            .map_err(UStatus::from)
+    }
+
+    async fn unregister_for_notifications(
+        &self,
+        notifications_unregister_request: NotificationsRequest,
+    ) -> Result<(), UStatus> {
+        self.rpc_client
+            .invoke_proto_method::<_, NotificationsResponse>(
+                usubscription_uri(RESOURCE_ID_UNREGISTER_FOR_NOTIFICATIONS),
+                Self::default_call_options(),
+                notifications_unregister_request,
+            )
+            .await
+            .map(|_response| ())
+            .map_err(UStatus::from)
+    }
+
+    async fn fetch_subscribers(
+        &self,
+        fetch_subscribers_request: FetchSubscribersRequest,
+    ) -> Result<FetchSubscribersResponse, UStatus> {
+        self.rpc_client
+            .invoke_proto_method::<_, FetchSubscribersResponse>(
+                usubscription_uri(RESOURCE_ID_FETCH_SUBSCRIBERS),
+                Self::default_call_options(),
+                fetch_subscribers_request,
+            )
+            .await
+            .map_err(UStatus::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mockall::Sequence;
+
+    use super::*;
+    use crate::{
+        communication::{rpc::MockRpcClient, UPayload},
+        core::usubscription::{Request, SubscriptionResponse},
+        UCode, UUri,
+    };
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_subscribe_invokes_rpc_client() {
+        let topic = UUri::try_from_parts("other", 0xd5a3, 0x01, 0xd3fe).unwrap();
+        let request = SubscriptionRequest {
+            topic: Some(topic).into(),
+            ..Default::default()
+        };
+        let expected_request = request.clone();
+        let mut rpc_client = MockRpcClient::new();
+        let mut seq = Sequence::new();
+        rpc_client
+            .expect_invoke_method()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(|method, _options, payload| {
+                method == &usubscription_uri(RESOURCE_ID_SUBSCRIBE) && payload.is_some()
+            })
+            .return_const(Err(crate::communication::ServiceInvocationError::Internal(
+                "internal error".to_string(),
+            )));
+        rpc_client
+            .expect_invoke_method()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(move |method, _options, payload| {
+                let request = payload
+                    .to_owned()
+                    .unwrap()
+                    .extract_protobuf::<SubscriptionRequest>()
+                    .unwrap();
+                request == expected_request && method == &usubscription_uri(RESOURCE_ID_SUBSCRIBE)
+            })
+            .returning(move |_method, _options, _payload| {
+                let response = SubscriptionResponse {
+                    ..Default::default()
+                };
+                Ok(Some(UPayload::try_from_protobuf(response).unwrap()))
+            });
+
+        let usubscription_client = RpcClientUSubscription::new(Arc::new(rpc_client));
+
+        assert!(usubscription_client
+            .subscribe(request.clone())
+            .await
+            .is_err_and(|e| e.get_code() == UCode::INTERNAL));
+        assert!(usubscription_client.subscribe(request).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_unsubscribe_invokes_rpc_client() {
+        let topic = UUri::try_from_parts("other", 0xd5a3, 0x01, 0xd3fe).unwrap();
+        let request = UnsubscribeRequest {
+            topic: Some(topic).into(),
+            ..Default::default()
+        };
+        let expected_request = request.clone();
+        let mut rpc_client = MockRpcClient::new();
+        let mut seq = Sequence::new();
+        rpc_client
+            .expect_invoke_method()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(|method, _options, payload| {
+                method == &usubscription_uri(RESOURCE_ID_UNSUBSCRIBE) && payload.is_some()
+            })
+            .return_const(Err(crate::communication::ServiceInvocationError::Internal(
+                "internal error".to_string(),
+            )));
+        rpc_client
+            .expect_invoke_method()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(move |method, _options, payload| {
+                let request = payload
+                    .to_owned()
+                    .unwrap()
+                    .extract_protobuf::<UnsubscribeRequest>()
+                    .unwrap();
+                request == expected_request && method == &usubscription_uri(RESOURCE_ID_UNSUBSCRIBE)
+            })
+            .returning(move |_method, _options, _payload| {
+                let response = UnsubscribeResponse {
+                    ..Default::default()
+                };
+                Ok(Some(UPayload::try_from_protobuf(response).unwrap()))
+            });
+
+        let usubscription_client = RpcClientUSubscription::new(Arc::new(rpc_client));
+
+        assert!(usubscription_client
+            .unsubscribe(request.clone())
+            .await
+            .is_err_and(|e| e.get_code() == UCode::INTERNAL));
+        assert!(usubscription_client.unsubscribe(request).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_subscriptions_invokes_rpc_client() {
+        let topic = UUri::try_from_parts("other", 0xd5a3, 0x01, 0xd3fe).unwrap();
+        let request = FetchSubscriptionsRequest {
+            request: Some(Request::Topic(topic)),
+            ..Default::default()
+        };
+        let expected_request = request.clone();
+        let mut rpc_client = MockRpcClient::new();
+        let mut seq = Sequence::new();
+        rpc_client
+            .expect_invoke_method()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(|method, _options, payload| {
+                method == &usubscription_uri(RESOURCE_ID_FETCH_SUBSCRIPTIONS) && payload.is_some()
+            })
+            .return_const(Err(crate::communication::ServiceInvocationError::Internal(
+                "internal error".to_string(),
+            )));
+        rpc_client
+            .expect_invoke_method()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(move |method, _options, payload| {
+                let request = payload
+                    .to_owned()
+                    .unwrap()
+                    .extract_protobuf::<FetchSubscriptionsRequest>()
+                    .unwrap();
+
+                request == expected_request
+                    && method == &usubscription_uri(RESOURCE_ID_FETCH_SUBSCRIPTIONS)
+            })
+            .returning(move |_method, _options, _payload| {
+                let response = FetchSubscriptionsResponse {
+                    ..Default::default()
+                };
+                Ok(Some(UPayload::try_from_protobuf(response).unwrap()))
+            });
+
+        let usubscription_client = RpcClientUSubscription::new(Arc::new(rpc_client));
+
+        assert!(usubscription_client
+            .fetch_subscriptions(request.clone())
+            .await
+            .is_err_and(|e| e.get_code() == UCode::INTERNAL));
+        assert!(usubscription_client
+            .fetch_subscriptions(request)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_subscribers_invokes_rpc_client() {
+        let topic = UUri::try_from_parts("other", 0xd5a3, 0x01, 0xd3fe).unwrap();
+        let request = FetchSubscribersRequest {
+            topic: Some(topic).into(),
+            ..Default::default()
+        };
+        let expected_request = request.clone();
+        let mut rpc_client = MockRpcClient::new();
+        let mut seq = Sequence::new();
+        rpc_client
+            .expect_invoke_method()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(|method, _options, payload| {
+                method == &usubscription_uri(RESOURCE_ID_FETCH_SUBSCRIBERS) && payload.is_some()
+            })
+            .return_const(Err(crate::communication::ServiceInvocationError::Internal(
+                "internal error".to_string(),
+            )));
+        rpc_client
+            .expect_invoke_method()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(move |method, _options, payload| {
+                let request = payload
+                    .to_owned()
+                    .unwrap()
+                    .extract_protobuf::<FetchSubscribersRequest>()
+                    .unwrap();
+
+                request == expected_request
+                    && method == &usubscription_uri(RESOURCE_ID_FETCH_SUBSCRIBERS)
+            })
+            .returning(move |_method, _options, _payload| {
+                let response = FetchSubscribersResponse {
+                    ..Default::default()
+                };
+                Ok(Some(UPayload::try_from_protobuf(response).unwrap()))
+            });
+
+        let usubscription_client = RpcClientUSubscription::new(Arc::new(rpc_client));
+
+        assert!(usubscription_client
+            .fetch_subscribers(request.clone())
+            .await
+            .is_err_and(|e| e.get_code() == UCode::INTERNAL));
+        assert!(usubscription_client
+            .fetch_subscribers(request)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_register_for_notifications_invokes_rpc_client() {
+        let topic = UUri::try_from_parts("other", 0xd5a3, 0x01, 0xd3fe).unwrap();
+        let request = NotificationsRequest {
+            topic: Some(topic).into(),
+            ..Default::default()
+        };
+        let expected_request = request.clone();
+        let mut rpc_client = MockRpcClient::new();
+        let mut seq = Sequence::new();
+        rpc_client
+            .expect_invoke_method()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(|method, _options, payload| {
+                method == &usubscription_uri(RESOURCE_ID_REGISTER_FOR_NOTIFICATIONS)
+                    && payload.is_some()
+            })
+            .return_const(Err(crate::communication::ServiceInvocationError::Internal(
+                "internal error".to_string(),
+            )));
+        rpc_client
+            .expect_invoke_method()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(move |method, _options, payload| {
+                let request = payload
+                    .to_owned()
+                    .unwrap()
+                    .extract_protobuf::<NotificationsRequest>()
+                    .unwrap();
+
+                request == expected_request
+                    && method == &usubscription_uri(RESOURCE_ID_REGISTER_FOR_NOTIFICATIONS)
+            })
+            .returning(move |_method, _options, _payload| {
+                let response = NotificationsResponse {
+                    ..Default::default()
+                };
+                Ok(Some(UPayload::try_from_protobuf(response).unwrap()))
+            });
+
+        let usubscription_client = RpcClientUSubscription::new(Arc::new(rpc_client));
+
+        assert!(usubscription_client
+            .register_for_notifications(request.clone())
+            .await
+            .is_err_and(|e| e.get_code() == UCode::INTERNAL));
+        assert!(usubscription_client
+            .register_for_notifications(request)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_unregister_for_notifications_invokes_rpc_client() {
+        let topic = UUri::try_from_parts("other", 0xd5a3, 0x01, 0xd3fe).unwrap();
+        let request = NotificationsRequest {
+            topic: Some(topic).into(),
+            ..Default::default()
+        };
+        let expected_request = request.clone();
+        let mut rpc_client = MockRpcClient::new();
+        let mut seq = Sequence::new();
+        rpc_client
+            .expect_invoke_method()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(|method, _options, payload| {
+                method == &usubscription_uri(RESOURCE_ID_UNREGISTER_FOR_NOTIFICATIONS)
+                    && payload.is_some()
+            })
+            .return_const(Err(crate::communication::ServiceInvocationError::Internal(
+                "internal error".to_string(),
+            )));
+        rpc_client
+            .expect_invoke_method()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(move |method, _options, payload| {
+                let request = payload
+                    .to_owned()
+                    .unwrap()
+                    .extract_protobuf::<NotificationsRequest>()
+                    .unwrap();
+
+                request == expected_request
+                    && method == &usubscription_uri(RESOURCE_ID_UNREGISTER_FOR_NOTIFICATIONS)
+            })
+            .returning(move |_method, _options, _payload| {
+                let response = NotificationsResponse {
+                    ..Default::default()
+                };
+                Ok(Some(UPayload::try_from_protobuf(response).unwrap()))
+            });
+
+        let usubscription_client = RpcClientUSubscription::new(Arc::new(rpc_client));
+
+        assert!(usubscription_client
+            .unregister_for_notifications(request.clone())
+            .await
+            .is_err_and(|e| e.get_code() == UCode::INTERNAL));
+        assert!(usubscription_client
+            .unregister_for_notifications(request)
+            .await
+            .is_ok());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,14 @@
 //! # up-rust  - uProtocol Rust library
 //!
 //! The purpose of this crate is to provide Rust specific code to work with the various
-//! [uProtocol Core API types](https://github.com/eclipse-uprotocol/up-core-api). The crate contains trait definitions and
-//! convenience functionality for building, converting, validating and serializing uProtocol data types.
+//! [uProtocol Core API types](https://github.com/eclipse-uprotocol/up-spec/tree/main/up-core-api).
+//! The crate contains trait definitions and convenience functionality for building, converting,
+//! validating and serializing uProtocol data types.
 //!
 //! ## Library contents
 //!
 //! * `communication` module, which defines uProtocol's Communication Layer API for publishing and subscribing to topics and invoking RPC methods.
+//!   It also contains a default implementation employing the Transport Layer API.
 //! * `uattributes` module, with uProtocol message attribute types and validators
 //! * `umessage` module, which defines the uProtocol core message type and provides related convenience functionality
 //! * `upayload` module, which defines payload representation for uProtocol messages
@@ -30,21 +32,22 @@
 //!
 //! For user convenience, all of these modules export their types on up_rust top-level, except for (future) optional features.
 //!
-//! ## Optional features
+//! ## Features
 //!
-//! Some crate features are made optional, these include:
-//!
-//! * `udiscovery` feature, which contains the generated protobuf stubs for [uProtocol Core API uDiscovery](https://raw.githubusercontent.com/eclipse-uprotocol/up-spec/main/up-l3/udiscovery/v3/README.adoc)
-//! * `usubscription` feature, which contains the generated protobuf stubs for [uProtocol Core API uSubscription](https://raw.githubusercontent.com/eclipse-uprotocol/up-spec/main/up-l3/usubscription/v3/README.adoc)
+//! * `communication` contains the [Communication Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/main/up-l2/api.adoc) and its
+//!   default implementation on top of the [Transport Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/main/up-l1/README.adoc).
+//!   Enabled by default.
+//! * `udiscovery` contains the generated protobuf stubs for [uProtocol Core API uDiscovery](https://raw.githubusercontent.com/eclipse-uprotocol/up-spec/main/up-l3/udiscovery/v3/README.adoc).
+//!   Enabled by default.
+//! * `usubscription` contains the generated protobuf stubs for [uProtocol Core API uSubscription](https://raw.githubusercontent.com/eclipse-uprotocol/up-spec/main/up-l3/usubscription/v3/README.adoc).
 //! * `utwin` feature, which contains the generated protobuf stubs for [uProtocol Core API uTwin](https://raw.githubusercontent.com/eclipse-uprotocol/up-spec/main/up-l3/utwin/v3/README.adoc)
 //!
 //! ## References
 //! * [Eclipse-uProtocol Specification](https://github.com/eclipse-uprotocol/up-spec)
-//! * [Eclipse-uProtocol Core API types](https://github.com/eclipse-uprotocol/up-core-api)
 
 // up_core_api types used and augmented by up_rust - symbols re-exported to toplevel, errors are module-specific
+#[cfg(feature = "communication")]
 pub mod communication;
-
 mod uattributes;
 pub use uattributes::{
     NotificationValidator, PublishValidator, RequestValidator, ResponseValidator,
@@ -74,5 +77,4 @@ mod up_core_api {
 // Types from up_core_api that we're not re-exporting for now (might change if need arises)
 // pub use up_core_api::file;
 // pub use up_core_api::uprotocol_options;
-
 pub mod core;


### PR DESCRIPTION
Added an implementation of the USubscription trait that works
with any RpcClient implementation.

Also added the "communication" feature which is enabled by default
and provides the Communication Layer API types and implementation.
The "communication" feature includes the "usubscription" feature.

This is for #122