### PR TITLE
Include the const exposure in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,11 +58,8 @@ pub use uattributes::{UAttributes, UAttributesError, UMessageType, UPayloadForma
 mod umessage;
 pub use umessage::{UMessage, UMessageBuilder, UMessageError};
 
-mod uri;
-pub use uri::{
-    UUri, UUriError, RESOURCE_ID_MIN_EVENT, RESOURCE_ID_RESPONSE, WILDCARD_AUTHORITY,
-    WILDCARD_ENTITY_ID, WILDCARD_ENTITY_VERSION, WILDCARD_RESOURCE_ID,
-};
+pub mod uri;
+pub use uri::{UUri, UUriError};
 
 mod ustatus;
 pub use ustatus::{UCode, UStatus};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,10 @@ mod umessage;
 pub use umessage::{UMessage, UMessageBuilder, UMessageError};
 
 mod uri;
-pub use uri::{UUri, UUriError};
+pub use uri::{
+    UUri, UUriError, RESOURCE_ID_MIN_EVENT, RESOURCE_ID_RESPONSE, WILDCARD_AUTHORITY,
+    WILDCARD_ENTITY_ID, WILDCARD_ENTITY_VERSION, WILDCARD_RESOURCE_ID,
+};
 
 mod ustatus;
 pub use ustatus::{UCode, UStatus};


### PR DESCRIPTION
As a following PR of https://github.com/eclipse-uprotocol/up-rust/pull/139. I forgot to include the exposure in `lib.rs`...