### PR TITLE
Customize automatic generation of release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,39 @@
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This is the configuration used by GitHub for automatically creating release notes
+# from pull requests based on their labels
+# see https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - wontfix
+      - invalid
+    authors:
+      - octocat
+  categories:
+    - title: "🛠️ Breaking Changes"
+      labels:
+        - "breaking change"
+    - title: "✨ Features"
+      labels:
+        - enhancement
+    - title: "🐛 Bug Fixes"
+      labels:
+        - bug
+    - title: "📚 Documentation"
+      labels:
+        - documentation
+    - title: "Other Changes"
+      labels:
+        - "*"


### PR DESCRIPTION
Added a configuration file that defines the categories to be used in
the release notes generated by GitHub.

This is for #164