### PR TITLE
Set resource ID to 0 while listening in InMemoryRpcServer.

### DIFF
--- a/src/communication/in_memory_rpc_server.rs
+++ b/src/communication/in_memory_rpc_server.rs
@@ -229,7 +229,9 @@ impl RpcServer for InMemoryRpcServer {
             });
             self.transport
                 .register_listener(
-                    origin_filter.unwrap_or(&UUri::any_with_resource_id(0)),
+                    origin_filter.unwrap_or(&UUri::any_with_resource_id(
+                        crate::uri::RESOURCE_ID_RESPONSE,
+                    )),
                     Some(&sink_filter),
                     listener.clone(),
                 )
@@ -258,7 +260,9 @@ impl RpcServer for InMemoryRpcServer {
             let listener = entry.get().to_owned();
             self.transport
                 .unregister_listener(
-                    origin_filter.unwrap_or(&UUri::any_with_resource_id(0)),
+                    origin_filter.unwrap_or(&UUri::any_with_resource_id(
+                        crate::uri::RESOURCE_ID_RESPONSE,
+                    )),
                     Some(&sink_filter),
                     listener,
                 )

--- a/src/communication/in_memory_rpc_server.rs
+++ b/src/communication/in_memory_rpc_server.rs
@@ -229,7 +229,7 @@ impl RpcServer for InMemoryRpcServer {
             });
             self.transport
                 .register_listener(
-                    origin_filter.unwrap_or(&UUri::any()),
+                    origin_filter.unwrap_or(&UUri::any_with_resource_id(0)),
                     Some(&sink_filter),
                     listener.clone(),
                 )
@@ -258,7 +258,7 @@ impl RpcServer for InMemoryRpcServer {
             let listener = entry.get().to_owned();
             self.transport
                 .unregister_listener(
-                    origin_filter.unwrap_or(&UUri::any()),
+                    origin_filter.unwrap_or(&UUri::any_with_resource_id(0)),
                     Some(&sink_filter),
                     listener,
                 )
@@ -310,7 +310,9 @@ mod tests {
         let request_handler = Arc::new(MockRequestHandler::new());
         let mut transport = MockTransport::new();
         let uri_provider = new_uri_provider();
-        let expected_source_filter = origin_filter.clone().unwrap_or(UUri::any());
+        let expected_source_filter = origin_filter
+            .clone()
+            .unwrap_or(UUri::any_with_resource_id(0));
         let param_check = move |source_filter: &UUri,
                                 sink_filter: &Option<&UUri>,
                                 _listener: &Arc<dyn UListener>| {

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -371,13 +371,7 @@ impl UUri {
 
     /// Gets a URI that consists of wildcards only and therefore matches any URI.
     pub fn any() -> Self {
-        UUri {
-            authority_name: WILDCARD_AUTHORITY.to_string(),
-            ue_id: WILDCARD_ENTITY_ID,
-            ue_version_major: WILDCARD_ENTITY_VERSION,
-            resource_id: WILDCARD_RESOURCE_ID,
-            ..Default::default()
-        }
+        Self::any_with_resource_id(WILDCARD_RESOURCE_ID)
     }
 
     /// Gets a URI that consists of wildcards and the specific resource ID.

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -380,6 +380,17 @@ impl UUri {
         }
     }
 
+    /// Gets a URI that consists of wildcards and the specific resource ID.
+    pub fn any_with_resource_id(resource_id: u32) -> Self {
+        UUri {
+            authority_name: WILDCARD_AUTHORITY.to_string(),
+            ue_id: WILDCARD_ENTITY_ID,
+            ue_version_major: WILDCARD_ENTITY_VERSION,
+            resource_id,
+            ..Default::default()
+        }
+    }
+
     /// Checks if this URI is empty.
     ///
     /// # Returns


### PR DESCRIPTION
The PR is to deal with https://github.com/eclipse-uprotocol/up-rust/issues/166.
If we don't configure the origin_filter, we'll use "//*/FFFF/FF/0" as the default.