### PR TITLE
Empty Authority field implies local UUri

### DIFF
--- a/src/communication.rs
+++ b/src/communication.rs
@@ -329,7 +329,7 @@ impl UPayload {
     /// # Errors
     ///
     /// * Err(`UMessageError`) if the unpacking process fails, for example if the payload could
-    /// not be deserialized into the target type `T`.
+    ///   not be deserialized into the target type `T`.
     ///
     ///
     /// # Examples

--- a/src/umessage.rs
+++ b/src/umessage.rs
@@ -175,7 +175,7 @@ impl UMessage {
     /// # Errors
     ///
     /// * Err(`UMessageError`) if the unpacking process fails, for example if the payload could
-    /// not be deserialized into the target type `T`.
+    ///   not be deserialized into the target type `T`.
     pub fn extract_protobuf<T: MessageFull + Default>(&self) -> Result<T, UMessageError> {
         if let Some(payload) = &self.payload {
             let payload_format = self.attributes.payload_format.enum_value_or_default();

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -389,7 +389,8 @@ impl UUri {
         self.eq(&UUri::default())
     }
 
-    /// Check if an `UUri` is remote, by comparing authority fields.
+    /// Check if an `UUri` is remote, by comparing authority fields. UUris with empty authority are
+    /// considered to be local.
     ///
     /// # Returns
     ///
@@ -406,7 +407,8 @@ impl UUri {
     /// assert!(authority_a.is_remote_authority(&authority_b));
     /// ````
     pub fn is_remote_authority(&self, other_uri: &UUri) -> bool {
-        self.authority_name != WILDCARD_AUTHORITY
+        !self.authority_name.is_empty()
+            && self.authority_name != WILDCARD_AUTHORITY
             && other_uri.authority_name != WILDCARD_AUTHORITY
             && self.authority_name != other_uri.authority_name
     }

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -407,7 +407,12 @@ impl UUri {
     /// assert!(authority_a.is_remote_authority(&authority_b));
     ///
     /// let authority_local = UUri::from_str("up:///100A/1/0").unwrap();
-    /// assert!(!authority_local.is_remote_authority(&authority_b));
+    /// assert!(!authority_local.is_remote_authority(&authority_a));
+    ///
+    /// let authority_wildcard = UUri::from_str("up://*/100A/1/0").unwrap();
+    /// assert!(!authority_local.is_remote_authority(&authority_a));
+    /// assert!(!authority_a.is_remote_authority(&authority_wildcard));
+    /// assert!(!authority_wildcard.is_remote_authority(&authority_wildcard));
     /// ````
     pub fn is_remote_authority(&self, other_uri: &UUri) -> bool {
         !self.authority_name.is_empty()

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -410,7 +410,7 @@ impl UUri {
     /// assert!(!authority_local.is_remote_authority(&authority_a));
     ///
     /// let authority_wildcard = UUri::from_str("up://*/100A/1/0").unwrap();
-    /// assert!(!authority_local.is_remote_authority(&authority_a));
+    /// assert!(!authority_wildcard.is_remote_authority(&authority_a));
     /// assert!(!authority_a.is_remote_authority(&authority_wildcard));
     /// assert!(!authority_wildcard.is_remote_authority(&authority_wildcard));
     /// ````

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -405,6 +405,9 @@ impl UUri {
     /// let authority_a = UUri::from_str("up://Authority.A/100A/1/0").unwrap();
     /// let authority_b = UUri::from_str("up://Authority.B/200B/2/20").unwrap();
     /// assert!(authority_a.is_remote_authority(&authority_b));
+    ///
+    /// let authority_local = UUri::from_str("up:///100A/1/0").unwrap();
+    /// assert!(!authority_local.is_remote_authority(&authority_b));
     /// ````
     pub fn is_remote_authority(&self, other_uri: &UUri) -> bool {
         !self.authority_name.is_empty()

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -302,7 +302,7 @@ impl FromStr for UUID {
     ///
     /// Returns an error
     /// * if the given string does not represent a UUID as defined by
-    /// [RFC 4122, Section 3](https://www.rfc-editor.org/rfc/rfc4122.html#section-3), or
+    ///   [RFC 4122, Section 3](https://www.rfc-editor.org/rfc/rfc4122.html#section-3), or
     /// * if the bytes encoded in the string contain an invalid version and/or variant identifier.
     ///
     /// # Examples


### PR DESCRIPTION
UUris with empty Authority are considered to be local - this was missing in the is_remote_uuri check.