### PR TITLE
Include requirements tracing in nightly up-spec compatibility check

### DIFF
--- a/.github/actions/run-oft/README.md
+++ b/.github/actions/run-oft/README.md
@@ -1,0 +1,11 @@
+Run OpenFastTrace CLI's `trace` command on the local `up-rust` workspace.
+
+Considers all (relevant) specification documents from the `up-spec` submodule and all
+implementation and documentation artifacts contained in the `up-rust` repository.
+
+The action installs Temurin JDK 17 for running OpenFastTrace (OFT) and has the following outputs:
+
+| Name                              | Description                                                                                                                                               |
+| :-------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `requirements-tracing-exit-code`  | 0: OFT has run successfully and all specification items are covered<br>1: OFT has either failed to run or at least one specification item is not covered. |
+| `requirements-tracing-report-url` | The URL pointing to the HTML report that has been created by OFT.                                                                                         |

--- a/.github/actions/run-oft/action.yaml
+++ b/.github/actions/run-oft/action.yaml
@@ -1,0 +1,87 @@
+# ********************************************************************************
+#  Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************/
+
+# Perform requirements tracing against the uProtocol Specification using OpenFastTrace (https://github.com/itsallcode/openfasttrace)
+# Returns the URL of the created HTML report as an output
+
+name: "Run OpenFastTrace"
+description: |
+  Runs OpenFastTrace with the trace command on the local up-rust workspace.
+outputs:
+  requirements-tracing-exit-code:
+    description: |
+      A flag indicating the outcome of running OpenFastTrace (0: success, 1: failure).
+      The report is created in any case, as long as OpenFastTrace could be run at all.
+    value: ${{ steps.run-oft.outputs.requirements-tracing-exit-code }}
+  requirements-tracing-report-url:
+    description: "The URL to the OpenFastTrace HTML report"
+    value: ${{ steps.tracing-report-html.artifact-url }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Prepare Environment
+      shell: bash
+      run: |
+        echo "TRACING_REPORT_FILE_NAME=requirements-tracing-report.html" >> $GITHUB_ENV
+    - name: Set up JDK
+      uses: actions/setup-java@v4
+      with:
+        distribution: "temurin"
+        java-version: "17"
+    - name: Download OpenFastTrace JARs
+      shell: bash
+      env:
+        OFT_REPO_BASE: "https://github.com/itsallcode"
+        OFT_CORE_VERSION: "4.1.0"
+        OFT_ASCIIDOC_PLUGIN_VERSION: "0.2.0"
+      run: |
+        mkdir "${{ github.workspace }}/lib"
+        curl -L -o "${{ github.workspace }}/lib/openfasttrace.jar" \
+          "${{ env.OFT_REPO_BASE }}/openfasttrace/releases/download/${{ env.OFT_CORE_VERSION }}/openfasttrace-${{ env.OFT_CORE_VERSION }}.jar"
+        curl -L -o "${{ github.workspace }}/lib/openfasttrace-asciidoc-plugin.jar" \
+          "${{ env.OFT_REPO_BASE }}/openfasttrace-asciidoc-plugin/releases/download/${{ env.OFT_ASCIIDOC_PLUGIN_VERSION }}/openfasttrace-asciidoc-plugin-${{ env.OFT_ASCIIDOC_PLUGIN_VERSION }}-with-dependencies.jar"
+    - name: Run OpenFastTrace
+      id: run-oft
+      shell: bash
+      run: |
+        if java -cp "${{ github.workspace }}/lib/*" \
+          org.itsallcode.openfasttrace.core.cli.CliStarter trace -o html \
+          -f "${{ env.TRACING_REPORT_FILE_NAME }}" \
+          *.md \
+          *.rs \
+          .github \
+          examples \
+          src \
+          tests \
+          tools \
+          up-spec/*.adoc \
+          up-spec/*.md \
+          up-spec/basics \
+          up-spec/up-l1/README.* \
+          up-spec/up-l2 \
+          up-spec/up-l3;
+        then
+          echo "requirements-tracing-exit-code=0" >> $GITHUB_OUTPUT
+          echo "All requirements from uProtocol Specification are covered by crate." >> $GITHUB_STEP_SUMMARY
+        else
+          echo "requirements-tracing-exit-code=1" >> $GITHUB_OUTPUT
+          echo "Some requirements from uProtocol Specification are not covered by crate. See attached report for details." >> $GITHUB_STEP_SUMMARY
+        fi
+
+    - name: Upload tracing report (html)
+      uses: actions/upload-artifact@v4
+      id: tracing-report-html
+      with:
+        name: tracing-report-html
+        path: ${{ env.TRACING_REPORT_FILE_NAME }}

--- a/.github/workflows/check-up-spec-compatibility.yaml
+++ b/.github/workflows/check-up-spec-compatibility.yaml
@@ -11,7 +11,8 @@
 #  SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************/
 
-# Verifies that this crate can be built with the most recent changes from up-spec's main branch
+# Verifies that this crate can be built using the uProtocol Core API from up-spec's main branch.
+# Also performs requirements tracing using OpenFastTrace
 
 name: uP Spec Compatibility
 
@@ -30,8 +31,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  nextest:
-    # Subset of feature-combos, on only one OS - more complete testing in test-featurematrix.yaml
+  tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -46,6 +46,14 @@ jobs:
           git pull
           git status
           cd "${{ github.workspace }}"
+
+      # run OpenFastTrace first because OFT will always succeed and produce
+      # a tracing report
+      - name: Run OpenFastTrace
+        uses: ./.github/actions/run-oft
+
+      # now try to build and run the tests which may fail if incomaptible changes
+      # have been introduced in up-spec
       - uses: dtolnay/rust-toolchain@master
         with: 
           toolchain: ${{ env.RUST_TOOLCHAIN }}

--- a/.github/workflows/requirements-tracing.yaml
+++ b/.github/workflows/requirements-tracing.yaml
@@ -25,69 +25,20 @@ on:
   workflow_dispatch:
   pull_request:
 
-env:
-  OFT_REPO_BASE: "https://github.com/itsallcode"
-  OFT_CORE_VERSION: "4.1.0"
-  OFT_ASCIIDOC_PLUGIN_VERSION: "0.2.0"
-  TRACING_REPORT_FILE_NAME: "requirements-tracing-report.html"
-          
 jobs:
   tracing:
     name: Run OpenFastTrace
     runs-on: ubuntu-latest
     outputs:
-      requirements-tracing-report-url: ${{ steps.tracing-report-html.outputs.artifact-url }}
+      requirements-tracing-report-url: ${{ steps.run-oft.outputs.requirements-tracing-report-url }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          java-version: "17"
 
-      - name: Download OpenFastTrace JARs
-        run: |
-          mkdir "${{ github.workspace }}/lib"
-          curl -L -o "${{ github.workspace }}/lib/openfasttrace.jar" \
-            "${{ env.OFT_REPO_BASE }}/openfasttrace/releases/download/${{ env.OFT_CORE_VERSION }}/openfasttrace-${{ env.OFT_CORE_VERSION }}.jar"
-          curl -L -o "${{ github.workspace }}/lib/openfasttrace-asciidoc-plugin.jar" \
-            "${{ env.OFT_REPO_BASE }}/openfasttrace-asciidoc-plugin/releases/download/${{ env.OFT_ASCIIDOC_PLUGIN_VERSION }}/openfasttrace-asciidoc-plugin-${{ env.OFT_ASCIIDOC_PLUGIN_VERSION }}-with-dependencies.jar"
       - name: Run OpenFastTrace
         id: run-oft
-        shell: bash
-        run: |
-          if java -cp "${{ github.workspace }}/lib/*" \
-            org.itsallcode.openfasttrace.core.cli.CliStarter trace -o html \
-            -f "${{ env.TRACING_REPORT_FILE_NAME }}" \
-            *.md \
-            *.rs \
-            .github \
-            examples \
-            src \
-            tests \
-            tools \
-            up-spec/*.adoc \
-            up-spec/*.md \
-            up-spec/basics \
-            up-spec/up-l1/README.* \
-            up-spec/up-l2 \
-            up-spec/up-l3;
-          then
-            echo "requirements-tracing-exit-code=0" >> $GITHUB_OUTPUT
-            echo "All requirements from uProtocol Specification are covered by crate." >> $GITHUB_STEP_SUMMARY
-          else
-            echo "requirements-tracing-exit-code=1" >> $GITHUB_OUTPUT
-            echo "Some requirements from uProtocol Specification are not covered by crate. See attached report for details." >> $GITHUB_STEP_SUMMARY
-          fi
-          
-      - name: Upload tracing report (html)
-        uses: actions/upload-artifact@v4
-        id: tracing-report-html
-        with:
-          name: tracing-report-html
-          path: ${{ env.TRACING_REPORT_FILE_NAME }}
+        uses: ./.github/actions/run-oft
 
       - name: "Determine exit code"
         run: |


### PR DESCRIPTION
Refactored OFT execution into its own composite GitHub Action in order
to be able to use it with both, the latest released up-spec as well as
the latest up-spec from the main branch.

This is for #180