### PR TITLE
Exclude L1 and L3 requirements from OFT check

### DIFF
--- a/.github/actions/run-oft/action.yaml
+++ b/.github/actions/run-oft/action.yaml
@@ -68,9 +68,7 @@ runs:
           up-spec/*.adoc \
           up-spec/*.md \
           up-spec/basics \
-          up-spec/up-l1/README.* \
-          up-spec/up-l2 \
-          up-spec/up-l3;
+          up-spec/up-l2/api.adoc;
         then
           echo "requirements-tracing-exit-code=0" >> $GITHUB_OUTPUT
           echo "All requirements from uProtocol Specification are covered by crate." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
The L1 and L3 specifications contain requirements for implementations
of the corresponding APIs and thus are not relevant for the Rust
language library, which only defines these APIs but does not
implement them.

Note that the library contains a (default) implementation of the L2
API and thus still needs to cover the requirements specified for L2.