### PR TITLE
Use GitHub variable to define OFT file patterns

### DIFF
--- a/.github/workflows/check-up-spec-compatibility.yaml
+++ b/.github/workflows/check-up-spec-compatibility.yaml
@@ -12,7 +12,9 @@
 # *******************************************************************************/
 
 # Verifies that this crate can be built using the uProtocol Core API from up-spec's main branch.
-# Also performs requirements tracing using OpenFastTrace
+# Also performs requirements tracing using OpenFastTrace. For that purpose, the workflow requires
+# the UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS variable to contain the file patterns to use for
+# invoking the "run-oft" Action.
 
 name: uP Spec Compatibility
 
@@ -52,7 +54,7 @@ jobs:
       - name: Run OpenFastTrace
         uses: ./.github/actions/run-oft
         with:
-          file-patterns: 'up-spec/*.adoc up-spec/*.md up-spec/basics up-spec/up-l2/api.adoc *.adoc *.md *.rs .github examples src tests tools'
+          file-patterns: ${{ vars.UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS }}
 
       # now try to build and run the tests which may fail if incomaptible changes
       # have been introduced in up-spec

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -53,3 +53,8 @@ jobs:
 
   coverage:
     uses: ./.github/workflows/coverage.yaml
+
+  requirements-tracing:
+    uses: ./.github/workflows/requirements-tracing.yaml
+    with:
+      oft-file-patterns: ${{ vars.UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS }}

--- a/.github/workflows/requirements-tracing.yaml
+++ b/.github/workflows/requirements-tracing.yaml
@@ -35,7 +35,6 @@ on:
           A whitespace separated list of glob patterns which specify the files to include in the OFT trace run.
           If not specified, defaults to all files relevant for checking up-rust against the uProtocol Specification.
         type: string
-  pull_request:
 
 jobs:
   tracing:
@@ -52,7 +51,7 @@ jobs:
         id: run-oft
         uses: ./.github/actions/run-oft
         with:
-          file-patterns: ${{ inputs.oft-file-patterns || 'up-spec/*.adoc up-spec/*.md up-spec/basics up-spec/up-l2/api.adoc *.adoc *.md *.rs .github examples src tests tools' }}
+          file-patterns: ${{ inputs.oft-file-patterns }}
 
       - name: "Determine exit code"
         run: |


### PR DESCRIPTION
Use UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS variable to look up the file patterns to use for running OFT.

Also adapted the run-oft Action to dynamically determine, if a JRE needs to be installed.