### PR TITLE
Fix OFT report file format

### DIFF
--- a/.github/actions/run-oft/action.yaml
+++ b/.github/actions/run-oft/action.yaml
@@ -47,6 +47,7 @@ runs:
       with:
         file-patterns: ${{ inputs.file-patterns }}
         report-filename: ${{ env.TRACING_REPORT_FILE_NAME }}
+        report-format: "html"
 
     - name: Upload tracing report (html)
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
The local composite action has been adapted to explicitly  set the
report format to "html" when invoking the standard OFT Action to
override the default ("plain").