### PR TITLE
Use separate repo variable for up-rust file patterns

### DIFF
--- a/.github/workflows/check-up-spec-compatibility.yaml
+++ b/.github/workflows/check-up-spec-compatibility.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Run OpenFastTrace
         uses: ./.github/actions/run-oft
         with:
-          file-patterns: ${{ vars.UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS }}
+          file-patterns: "${{ vars.UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS }} ${{ vars.UP_RUST_OPEN_FAST_TRACE_FILE_PATTERNS }}"
 
       # now try to build and run the tests which may fail if incomaptible changes
       # have been introduced in up-spec

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -57,4 +57,4 @@ jobs:
   requirements-tracing:
     uses: ./.github/workflows/requirements-tracing.yaml
     with:
-      oft-file-patterns: ${{ vars.UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS }}
+      oft-file-patterns: "${{ vars.UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS }} ${{ vars.UP_RUST_OPEN_FAST_TRACE_FILE_PATTERNS }}"


### PR DESCRIPTION
The workflows that run OpenFastTrace for checking coverage of
requirements from up-spec have been adapted to use a separate
repo variable that contains the file patterns for artifacts from
up-rust that cover the requirements.