### PR TITLE
Include tracing report in release artifacts

### DIFF
--- a/.github/workflows/license-report.yaml
+++ b/.github/workflows/license-report.yaml
@@ -22,7 +22,7 @@ on:
     outputs:
       license_report_url:
         description: "URL of the license report artifact"
-        value: ${{ jobs.coverage.outputs.test_coverage_url }}
+        value: ${{ jobs.license_check.outputs.license_report_url }}
   workflow_dispatch:
           
 env:
@@ -31,11 +31,11 @@ env:
     CARGO_TERM_COLOR: always
       
 jobs:
-  coverage:
+  license_check:
     name: create
     runs-on: ubuntu-latest
     outputs:
-      test_coverage_url: ${{ steps.license_report.outputs.artifact-url }}
+      license_report_url: ${{ steps.license_report.outputs.artifact-url }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -50,7 +50,6 @@ jobs:
         cargo install cargo-about
     - name: Create license report
       run: |
-        mkdir -p release
         cargo about generate about.hbs > licenses.html
     - uses: actions/upload-artifact@v4
       id: license_report

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************/
 
-# Create artifacts for project releases 
-# Note: might also include crates.io publication step, if we're confident about our overall workflow
+# Create artifacts for project releases
 
 name: Release
 
@@ -20,8 +19,7 @@ on:
   push:
     tags:
       - v*
-  workflow_dispatch:
-  
+
 concurrency:
   group: "release-${{ github.head_ref || github.ref }}"
   cancel-in-progress: true
@@ -36,44 +34,14 @@ jobs:
   coverage:
     uses: ./.github/workflows/coverage.yaml  
 
+  requirements-tracing:
+    uses: ./.github/workflows/requirements-tracing.yaml
+    with:
+      oft-file-patterns: "${{ vars.UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS }} ${{ vars.UP_RUST_OPEN_FAST_TRACE_FILE_PATTERNS }}"
+
   licenses:
     # This works off the license declarations in dependent packages/crates, so if these declarations are wrong, this report will contain erroneous information
     uses: ./.github/workflows/license-report.yaml  
-
-  release:
-    name: collect workflow artifacts
-    runs-on: ubuntu-latest
-    needs: 
-      - check
-      - check-msrv
-      - coverage
-      - licenses
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
-
-      - name: Upload README
-        id: upload_readme
-        uses: actions/upload-artifact@v4
-        with:
-          name: readme
-          path: README.md
-        
-      - name: Collect quality artifacts
-        uses: anotherdaniel/quevee@v0.2.0
-        id: quevee
-        with:          
-          release_url: ${{ github.ref_name }}
-          artifacts_license: ${{ needs.licenses.outputs.license_report_url }}
-          artifacts_readme: ${{ steps.upload_readme.outputs.artifact-url }}
-          artifacts_testing: ${{ needs.check.outputs.test_results_url }},${{ needs.coverage.outputs.test_coverage_url }}
-
-      - name: Store quality manifest as workflow artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: quality-artifacts-manifest
-          path: ${{ steps.quevee.outputs.manifest_file }}
 
   tag_release_artifacts:
     # This only runs if this workflow is initiated via a tag-push with pattern 'v*'
@@ -82,7 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: 
       - check
+      - check-msrv
       - coverage
+      - requirements-tracing
       - licenses
     permissions: write-all
     steps:
@@ -102,6 +72,21 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/license/*
+          file_glob: true
+          tag: ${{ github.ref }}
+
+      # Requirements Tracing report - we later need the download_url output of the upload step
+      - name: Download requirements tracing report
+        uses: actions/download-artifact@v4
+        with:
+          name: tracing-report-html
+          path: dist/tracing/
+      - name: Upload requirements tracing report to release
+        uses: svenstaro/upload-release-action@v2
+        id: upload_requirements_tracing_report
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/tracing/*
           file_glob: true
           tag: ${{ github.ref }}
 
@@ -144,6 +129,18 @@ jobs:
           file: README.md
           tag: ${{ github.ref }}
 
+      - name: Gather uProtocol Specification documents
+        shell: bash
+        run: |
+          tar cvz --file up-spec.tar.gz ${{ vars.UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS }}
+      - name: Upload relevant uProtocol Spec files to release
+        uses: svenstaro/upload-release-action@v2
+        id: upload_up_spec
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: up-spec.tar.gz
+          tag: ${{ github.ref }}
+
       - name: Gets latest created release info
         id: latest_release_info
         uses: joutvhu/get-release@v1
@@ -151,13 +148,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
       - name: Collect quality artifacts
-        uses: anotherdaniel/quevee@v0.3.0
+        uses: anotherdaniel/quevee@v0.4.1
         id: quevee_manifest
         with:          
           release_url: ${{ steps.latest_release_info.outputs.html_url }}
           artifacts_license: ${{ steps.upload_license_report.outputs.browser_download_url }}
           artifacts_readme: ${{ steps.upload_readme.outputs.browser_download_url }}
-          artifacts_testing: ${{ steps.upload_test_report.outputs.browser_download_url }},${{ steps.upload_test_coverage.outputs.browser_download_url }}
+          artifacts_requirements: ${{ steps.upload_up_spec.outputs.browser_download_url }}
+          artifacts_testing: ${{ steps.upload_test_report.outputs.browser_download_url }},${{ steps.upload_test_coverage.outputs.browser_download_url }},${{ steps.upload_requirements_tracing_report.outputs.browser_download_url }}
 
       - name: Upload manifest to release
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
The release CI workflow has been adapted to include the requirements tracing report created with OpenFastTrace. The uProtocol Specification artifacts that are relevant to up-rust are now also attached to the release.