### PR TITLE
Prepare 0.2.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "up-rust"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ name = "up-rust"
 readme = "README.md"
 repository = "https://github.com/eclipse-uprotocol/up-rust"
 rust-version = "1.74.1"
-version = "0.1.5"
+version = "0.2.0"
 
 [features]
 default = ["communication"]


### PR DESCRIPTION
Added some new behavior so using a new minor version seems
reasonable, in order to make this more transparent.