### PR TITLE
Add simple LocalUriProvider implementation

### DIFF
--- a/src/communication/default_notifier.rs
+++ b/src/communication/default_notifier.rs
@@ -107,27 +107,12 @@ mod tests {
     use protobuf::well_known_types::wrappers::StringValue;
 
     use crate::{
-        utransport::{MockLocalUriProvider, MockTransport, MockUListener},
-        UCode, UPriority, UStatus, UUri, UUID,
+        utransport::{MockTransport, MockUListener},
+        StaticUriProvider, UCode, UPriority, UStatus, UUri, UUID,
     };
 
     fn new_uri_provider() -> Arc<dyn LocalUriProvider> {
-        let mut mock_uri_locator = MockLocalUriProvider::new();
-        mock_uri_locator
-            .expect_get_resource_uri()
-            .returning(|resource_id| UUri {
-                ue_id: 0x0005,
-                ue_version_major: 0x02,
-                resource_id: resource_id as u32,
-                ..Default::default()
-            });
-        mock_uri_locator.expect_get_source_uri().returning(|| UUri {
-            ue_id: 0x0005,
-            ue_version_major: 0x02,
-            resource_id: 0x0000,
-            ..Default::default()
-        });
-        Arc::new(mock_uri_locator)
+        Arc::new(StaticUriProvider::new("", 0x0005, 0x02))
     }
 
     #[tokio::test]

--- a/src/communication/default_pubsub.rs
+++ b/src/communication/default_pubsub.rs
@@ -467,27 +467,12 @@ mod tests {
 
     use crate::{
         communication::{notification::MockNotifier, pubsub::MockSubscriptionChangeHandler},
-        utransport::{MockLocalUriProvider, MockTransport, MockUListener},
-        UAttributes, UCode, UMessageType, UPriority, UStatus, UUri, UUID,
+        utransport::{MockTransport, MockUListener},
+        StaticUriProvider, UAttributes, UCode, UMessageType, UPriority, UStatus, UUri, UUID,
     };
 
     fn new_uri_provider() -> Arc<dyn LocalUriProvider> {
-        let mut mock_uri_locator = MockLocalUriProvider::new();
-        mock_uri_locator
-            .expect_get_resource_uri()
-            .returning(|resource_id| UUri {
-                ue_id: 0x0005,
-                ue_version_major: 0x02,
-                resource_id: resource_id as u32,
-                ..Default::default()
-            });
-        mock_uri_locator.expect_get_source_uri().returning(|| UUri {
-            ue_id: 0x0005,
-            ue_version_major: 0x02,
-            resource_id: 0x0000,
-            ..Default::default()
-        });
-        Arc::new(mock_uri_locator)
+        Arc::new(StaticUriProvider::new("", 0x0005, 0x02))
     }
 
     fn succeding_notifier() -> Arc<dyn Notifier> {

--- a/src/communication/in_memory_rpc_client.rs
+++ b/src/communication/in_memory_rpc_client.rs
@@ -298,20 +298,10 @@ mod tests {
     use protobuf::{well_known_types::wrappers::StringValue, Enum};
     use tokio::{join, sync::Notify};
 
-    use crate::{
-        utransport::{MockLocalUriProvider, MockTransport},
-        UMessageBuilder, UPriority, UUri,
-    };
+    use crate::{utransport::MockTransport, StaticUriProvider, UMessageBuilder, UPriority, UUri};
 
     fn new_uri_provider() -> Arc<dyn LocalUriProvider> {
-        let mut mock_uri_locator = MockLocalUriProvider::new();
-        mock_uri_locator.expect_get_source_uri().returning(|| UUri {
-            ue_id: 0x0005,
-            ue_version_major: 0x02,
-            resource_id: 0x0000,
-            ..Default::default()
-        });
-        Arc::new(mock_uri_locator)
+        Arc::new(StaticUriProvider::new("", 0x0005, 0x02))
     }
 
     fn service_method_uri() -> UUri {

--- a/src/communication/in_memory_rpc_server.rs
+++ b/src/communication/in_memory_rpc_server.rs
@@ -291,22 +291,12 @@ mod tests {
     use tokio::sync::Notify;
 
     use crate::{
-        communication::rpc::MockRequestHandler,
-        utransport::{MockLocalUriProvider, MockTransport},
+        communication::rpc::MockRequestHandler, utransport::MockTransport, StaticUriProvider,
         UAttributes, UMessageType, UPriority, UUri, UUID,
     };
 
     fn new_uri_provider() -> Arc<dyn LocalUriProvider> {
-        let mut mock_uri_provider = MockLocalUriProvider::new();
-        mock_uri_provider
-            .expect_get_resource_uri()
-            .returning(|resource_id| UUri {
-                ue_id: 0x0005,
-                ue_version_major: 0x02,
-                resource_id: resource_id as u32,
-                ..Default::default()
-            });
-        Arc::new(mock_uri_provider)
+        Arc::new(StaticUriProvider::new("", 0x0005, 0x02))
     }
 
     #[test_case(None, 0x4A10; "for empty origin filter")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,9 @@ mod ustatus;
 pub use ustatus::{UCode, UStatus};
 
 mod utransport;
-pub use utransport::{ComparableListener, LocalUriProvider, UListener, UTransport};
+pub use utransport::{
+    ComparableListener, LocalUriProvider, StaticUriProvider, UListener, UTransport,
+};
 mod uuid;
 pub use uuid::UUID;
 


### PR DESCRIPTION
Added StaticUriProvider which is configured using static information.
StaticUriProvider is supposed to be used by transport implementations
and/or test cases.