### PR TITLE
Use StaticUriProvider in examples

### DIFF
--- a/examples/simple_notify.rs
+++ b/examples/simple_notify.rs
@@ -17,7 +17,7 @@ use protobuf::well_known_types::wrappers::StringValue;
 use up_rust::{
     communication::{CallOptions, Notifier, SimpleNotifier, UPayload},
     local_transport::LocalTransport,
-    LocalUriProvider, UListener, UMessage,
+    LocalUriProvider, StaticUriProvider, UListener, UMessage,
 };
 
 struct ConsolePrinter {}
@@ -35,9 +35,9 @@ impl UListener for ConsolePrinter {
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     const ORIGIN_RESOURCE_ID: u16 = 0xd100;
 
-    let transport = Arc::new(LocalTransport::new("my-vehicle", 0xa34b, 0x01));
-    let uri_provider: Arc<dyn LocalUriProvider> = transport.clone();
-    let notifier = SimpleNotifier::new(transport.clone(), uri_provider.clone());
+    let uri_provider = Arc::new(StaticUriProvider::new("my-vehicle", 0xa34b, 0x01));
+    let transport = Arc::new(LocalTransport::default());
+    let notifier = SimpleNotifier::new(transport, uri_provider.clone());
     let topic = uri_provider.get_resource_uri(ORIGIN_RESOURCE_ID);
     let listener = Arc::new(ConsolePrinter {});
 

--- a/examples/simple_publish.rs
+++ b/examples/simple_publish.rs
@@ -17,7 +17,7 @@ use protobuf::well_known_types::wrappers::StringValue;
 use up_rust::{
     communication::{CallOptions, Publisher, SimplePublisher, UPayload},
     local_transport::LocalTransport,
-    LocalUriProvider, UListener, UMessage, UTransport,
+    LocalUriProvider, StaticUriProvider, UListener, UMessage, UTransport,
 };
 
 struct ConsolePrinter {}
@@ -34,8 +34,8 @@ impl UListener for ConsolePrinter {
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     const ORIGIN_RESOURCE_ID: u16 = 0xb4c1;
-    let transport = Arc::new(LocalTransport::new("my-vehicle", 0xa34b, 0x01));
-    let uri_provider: Arc<dyn LocalUriProvider> = transport.clone();
+    let uri_provider = Arc::new(StaticUriProvider::new("my-vehicle", 0xa34b, 0x01));
+    let transport = Arc::new(LocalTransport::default());
     let publisher = SimplePublisher::new(transport.clone(), uri_provider.clone());
     let listener = Arc::new(ConsolePrinter {});
 

--- a/examples/simple_rpc.rs
+++ b/examples/simple_rpc.rs
@@ -24,7 +24,7 @@ use up_rust::{
         ServiceInvocationError, UPayload,
     },
     local_transport::LocalTransport,
-    LocalUriProvider,
+    LocalUriProvider, StaticUriProvider,
 };
 
 struct EchoOperation {}
@@ -49,8 +49,8 @@ impl RequestHandler for EchoOperation {
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     const METHOD_RESOURCE_ID: u16 = 0x00a0;
-    let transport = Arc::new(LocalTransport::new("my-vehicle", 0xa34b, 0x01));
-    let uri_provider: Arc<dyn LocalUriProvider> = transport.clone();
+    let uri_provider = Arc::new(StaticUriProvider::new("my-vehicle", 0xa34b, 0x01));
+    let transport = Arc::new(LocalTransport::default());
 
     // create the RpcServer using the local transport
     let rpc_server = InMemoryRpcServer::new(transport.clone(), uri_provider.clone());
@@ -62,7 +62,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // now create an RpcClient attached to the same local transport
-    let rpc_client = InMemoryRpcClient::new(transport.clone(), uri_provider.clone()).await?;
+    let rpc_client = InMemoryRpcClient::new(transport, uri_provider.clone()).await?;
     // and invoke the service operation without any payload
     match rpc_client
         .invoke_method(


### PR DESCRIPTION
The examples have been changed to use StaticUriProvider instead of
having LocalTransport implement LocalUriProvider.