### PR TITLE
Fix MSRV check in nightly build

### DIFF
--- a/.github/workflows/verify-msrv.yaml
+++ b/.github/workflows/verify-msrv.yaml
@@ -37,4 +37,4 @@ jobs:
     - name: check MSRV
       run: |
         cargo install cargo-msrv
-        cargo msrv --verify
+        cargo msrv verify


### PR DESCRIPTION
The "--verify" parameter has been removed in version 0.16 of the
msrv-check cargo plugin. The command line to run the check has been
adapted accordingly.

addresses #207 