### PR TITLE
Add message metadata to RpcHandler

### DIFF
--- a/examples/simple_rpc.rs
+++ b/examples/simple_rpc.rs
@@ -24,7 +24,7 @@ use up_rust::{
         ServiceInvocationError, UPayload,
     },
     local_transport::LocalTransport,
-    LocalUriProvider, StaticUriProvider,
+    LocalUriProvider, StaticUriProvider, UAttributes,
 };
 
 struct EchoOperation {}
@@ -34,6 +34,7 @@ impl RequestHandler for EchoOperation {
     async fn handle_request(
         &self,
         _resource_id: u16,
+        _message_attributes: &UAttributes,
         request_payload: Option<UPayload>,
     ) -> Result<Option<UPayload>, ServiceInvocationError> {
         if let Some(req_payload) = request_payload {

--- a/src/communication/rpc.rs
+++ b/src/communication/rpc.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 use protobuf::MessageFull;
 
 use crate::communication::RegistrationError;
-use crate::{UCode, UStatus, UUri};
+use crate::{UAttributes, UCode, UStatus, UUri};
 
 use super::{CallOptions, UPayload};
 
@@ -223,6 +223,7 @@ pub trait RequestHandler: Send + Sync {
     /// # Arguments
     ///
     /// * `resource_id` - The resource identifier of the method to invoke.
+    /// * `message_attributes` - Any metadata that is associated with the request message.
     /// * `request_payload` - The raw payload that contains the input data for the method.
     ///
     /// # Returns
@@ -235,6 +236,7 @@ pub trait RequestHandler: Send + Sync {
     async fn handle_request(
         &self,
         resource_id: u16,
+        message_attributes: &UAttributes,
         request_payload: Option<UPayload>,
     ) -> Result<Option<UPayload>, ServiceInvocationError>;
 }


### PR DESCRIPTION
Currently, rpc RequestHandler does not provide access to received message metadata like message source, payload format etc.

This PR adds message UAttributes to the RequestHandlers `handle_request()` method trait and modifies InMemoryRpcServer to pass this information on when calling into a handler.

Adresses #222 