### PR TITLE
Recurse submodules when checking out repo

### DIFF
--- a/.github/workflows/verify-latest-deps.yaml
+++ b/.github/workflows/verify-latest-deps.yaml
@@ -33,6 +33,8 @@ jobs:
       CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: allow
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: "recursive"
     - run: rustup update stable && rustup default stable
     - run: cargo update --verbose
     - run: cargo build --verbose --all-features


### PR DESCRIPTION
The workflow for checking if the code can be compiled using the latest versions of 3rd party dependencies had failed sporadically because the uProtocol API proto3 files had not been available.

This was due to the fact that the up-spec submodule had not been properly initialized during checkout.

Addresses #230