### PR TITLE
Improve cargo deny check run during nightly

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -37,6 +37,8 @@ jobs:
 
   deny:
     uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-deny-check.yaml@main
+    with:
+      arguments: --all-features --locked --exclude-dev
 
   # [impl->req~up-language-ci-test~1]
   test-all-features:


### PR DESCRIPTION
Use locked dependencies when performing the check in order to get
reproducible results. Also exclude dev dependencies from checks.