### PR TITLE
Increase MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ license = "Apache-2.0"
 name = "up-rust"
 readme = "README.md"
 repository = "https://github.com/eclipse-uprotocol/up-rust"
-rust-version = "1.76"
+rust-version = "1.82"
 version = "0.5.0"
 
 [features]


### PR DESCRIPTION
to enable more recent language constructs like Option::is_none_or
which make the code easier to write (and understand).

This should be in line with our general practice of keeping close
to the most recent Rust version.