### PR TITLE
Use shared Action for running Eclipse Dash Licenses tool

### DIFF
--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -32,42 +32,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: cargo tree
+    - name: Determine 3rd party dependencies
       working-directory: ${{github.workspace}}
       run: |
-        cargo tree -e no-build,no-dev --prefix none --no-dedupe \
+        cargo tree --all-features --locked -e no-build,no-dev --prefix none --no-dedupe \
           | sort -u \
           | grep -v '^[[:space:]]*$' \
           | grep -v up-rust \
           | sed -E 's|([^ ]+) v([^ ]+).*|crate/cratesio/-/\1/\2|' \
           > DEPS.txt
-    - name: Set up JDK
-      uses: actions/setup-java@v4
+    - name: Run Eclipse Dash Licenses tool
+      uses: eclipse-uprotocol/ci-cd/.github/actions/run-eclipse-dash@main
       with:
-        distribution: "temurin"
-        java-version: "17"
-    - name: "Run latest Eclipse Dash jar file"
-      id: "run-checks"
-      working-directory: ${{github.workspace}}
-      run: |
-        wget --quiet -O dash.jar "https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST"
-        if java -Dorg.eclipse.dash.timeout=60 -jar dash.jar -batch 90 -summary DEPENDENCIES.txt DEPS.txt
-        then
-          echo "checks-failed=0" >> $GITHUB_OUTPUT
-          echo "License information of 3rd party dependencies has been vetted successfully." >> $GITHUB_STEP_SUMMARY
-        else
-          echo "checks-failed=1" >> $GITHUB_OUTPUT
-          echo "License information of some 3rd party dependencies could not be vetted successfully." >> $GITHUB_STEP_SUMMARY
-          echo "A DEPENDENCIES file containing the vetted information has been attached to this workflow run." >> $GITHUB_STEP_SUMMARY
-        fi
-    - name: Upload DEPENDENCIES file
-      if: ${{ steps.run-checks.outputs.checks-failed == '1' }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: 3rd-party-dependencies
-        path: DEPENDENCIES.txt
-    - name: "Determine exit code"
-      env:
-        EXIT_CODE: ${{ steps.run-checks.outputs.checks-failed }}
-      run: |
-        exit $EXIT_CODE
+        components-file: DEPS.txt


### PR DESCRIPTION
The CI job for checking 3rd party dependencies' licenses has been
adapted to use the corresponding GitHub Action from
eclipse-uprotocol/ci-cd.