### PR TITLE
Fix nightly execution of requirements tracing

### DIFF
--- a/.github/workflows/check-up-spec-compatibility.yaml
+++ b/.github/workflows/check-up-spec-compatibility.yaml
@@ -54,7 +54,7 @@ jobs:
         id: run-oft
         uses: eclipse-uprotocol/ci-cd/.github/actions/run-oft@main
         with:
-          file-patterns: "${{ vars.UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS }} ${{ vars.UP_COMPONENT_OPEN_FAST_TRACE_FILE_PATTERNS }}"
+          file-patterns: "up-spec/*.adoc up-spec/*.md up-spec/basics up-spec/up-l1/README.adoc up-spec/up-l1/cloudevents.adoc up-spec/up-l2/api.adoc *.adoc *.md *.rs .github examples src tests tools"
           tags: "_,LanguageLibrary"
 
       # now try to build and run the tests which may fail if incomaptible changes

--- a/.github/workflows/current-up-spec-compliance.yaml
+++ b/.github/workflows/current-up-spec-compliance.yaml
@@ -1,0 +1,39 @@
+# ********************************************************************************
+#  Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************/
+
+# Verifies that this crate covers all requirements of the (currently) implemented
+# version of the uProtocol Specification.
+
+name: Current uP Spec Compliance
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+env:
+  RUST_TOOLCHAIN: ${{ vars.RUST_TOOLCHAIN || 'stable' }}
+  RUSTFLAGS: -Dwarnings
+  CARGO_TERM_COLOR: always
+
+jobs:
+  requirements-tracing:
+    uses: eclipse-uprotocol/ci-cd/.github/workflows/requirements-tracing.yaml@main
+    # Do not include the recently revamped L1 API spec with requirements for
+    # language libraries.
+    # We also do not use OFT Tags for filtering specitems (yet).
+    with:
+      oft-file-patterns: "up-spec/*.adoc up-spec/*.md up-spec/basics up-spec/up-l1/cloudevents.adoc up-spec/up-l2/api.adoc *.adoc *.md *.rs .github examples src tests tools"

--- a/.github/workflows/latest-up-spec-compatibility.yaml
+++ b/.github/workflows/latest-up-spec-compatibility.yaml
@@ -15,7 +15,7 @@
 # Also performs requirements tracing using OpenFastTrace. The job fails if any of the two
 # activities fail.
 
-name: uP Spec Compatibility
+name: Latest uP Spec Compatibility
 
 on:
   schedule:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -51,11 +51,5 @@ jobs:
   coverage:
     uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-coverage.yaml@main
 
-  # This check still is based on up-spec v1.6.0_alpha.4
-  # It therefore does not include the recently revamped L1 API spec with requirements for
-  # language libraries.
-  # We also do not use OFT Tags for filtering specitems (yet).
   requirements-tracing:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/requirements-tracing.yaml@main
-    with:
-      oft-file-patterns: "up-spec/*.adoc up-spec/*.md up-spec/basics up-spec/up-l1/cloudevents.adoc up-spec/up-l2/api.adoc *.adoc *.md *.rs .github examples src tests tools"
+    uses: ./.github/workflows/current-up-spec-compliance.yaml

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -51,7 +51,11 @@ jobs:
   coverage:
     uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-coverage.yaml@main
 
+  # This check still is based on up-spec v1.6.0_alpha.4
+  # It therefore does not include the recently revamped L1 API spec with requirements for
+  # language libraries.
+  # We also do not use OFT Tags for filtering specitems (yet).
   requirements-tracing:
     uses: eclipse-uprotocol/ci-cd/.github/workflows/requirements-tracing.yaml@main
     with:
-      oft-file-patterns: "${{ vars.UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS }} ${{ vars.UP_RUST_OPEN_FAST_TRACE_FILE_PATTERNS }}"
+      oft-file-patterns: "up-spec/*.adoc up-spec/*.md up-spec/basics up-spec/up-l1/cloudevents.adoc up-spec/up-l2/api.adoc *.adoc *.md *.rs .github examples src tests tools"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,9 +35,7 @@ jobs:
     uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-coverage.yaml@main 
 
   requirements-tracing:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/requirements-tracing.yaml@main
-    with:
-      oft-file-patterns: "${{ vars.UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS }} ${{ vars.UP_RUST_OPEN_FAST_TRACE_FILE_PATTERNS }}"
+    uses: ./.github/workflows/current-up-spec-compliance.yaml
 
   licenses:
     # This works off the license declarations in dependent packages/crates, so if these declarations are wrong, this report will contain erroneous information


### PR DESCRIPTION
The check has failed recently because it had been erroneously using
the file patterns that refer to the current (not yet released) state
of up-spec.

Also replaced GitHub repo variables with explicit specification of
file patterns in order to have more flexibility when defining the
scope of the check.