### PR TITLE
Add helper function for validating filter criteria

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,8 @@ pub use ustatus::{UCode, UStatus};
 
 mod utransport;
 pub use utransport::{
-    ComparableListener, LocalUriProvider, StaticUriProvider, UListener, UTransport,
+    verify_filter_criteria, ComparableListener, LocalUriProvider, StaticUriProvider, UListener,
+    UTransport,
 };
 #[cfg(feature = "test-util")]
 pub use utransport::{MockLocalUriProvider, MockTransport, MockUListener};


### PR DESCRIPTION
The UTransport::register_listener function is required to return an
Error if the given filter criteria (UUris) are invalid.

Added a helper method to be used by UTransport implementations that
implements this check.