### PR TITLE
Rebase on up-spec v1.6.0-alpha.5

### DIFF
--- a/.env.oft-current
+++ b/.env.oft-current
@@ -13,11 +13,11 @@
 
 # The file patterns that specify the relevant parts of the uProtocol Specification
 # that this component is supposed to implement
-UP_SPEC_FILE_PATTERNS="up-spec/*.adoc up-spec/*.md up-spec/basics up-spec/up-l1/cloudevents.adoc up-spec/up-l2/api.adoc"
+UP_SPEC_FILE_PATTERNS="up-spec/*.adoc up-spec/*.md up-spec/basics up-spec/up-l1/README.adoc up-spec/up-l1/cloudevents.adoc up-spec/up-l2/api.adoc"
 
 # The file patterns that specify this component's resources which contain specification items
 # that cover the requirements
 COMPONENT_FILE_PATTERNS="*.adoc *.md *.rs .github examples src tests tools"
 
 OFT_FILE_PATTERNS="$UP_SPEC_FILE_PATTERNS $COMPONENT_FILE_PATTERNS"
-OFT_TAGS=""
+OFT_TAGS="_,LanguageLibrary"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Eclipse uProtocol Rust library
 
-This is the [uProtocol v1.6.0-alpha.4 Language Library](https://github.com/eclipse-uprotocol/uprotocol-spec/blob/v1.6.0-alpha.4/languages.adoc) for the Rust programming language.
+This is the [uProtocol v1.6.0-alpha.5 Language Library](https://github.com/eclipse-uprotocol/uprotocol-spec/blob/v1.6.0-alpha.5/languages.adoc) for the Rust programming language.
 
 The crate can be used to
 
-* implement uEntities that communicate with each other using the uProtocol [Communication Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.4/up-l2/api.adoc) over one of the supported transport protocols.
-* implement support for an additional transport protocol by means of implementing the [Transport Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.4/up-l1/README.adoc).
+* implement uEntities that communicate with each other using the uProtocol [Communication Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.5/up-l2/api.adoc) over one of the supported transport protocols.
+* implement support for an additional transport protocol by means of implementing the [Transport Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.5/up-l1/README.adoc).
 
 ## Using the Crate
 <!--
@@ -17,7 +17,7 @@ The crate needs to be added to the `[dependencies]` section of the `Cargo.toml` 
 
 ```toml
 [dependencies]
-up-rust = { version = "0.1" }
+up-rust = { version = "0.5" }
 ```
 
 Most developers will want to use the Communication Level API and its default implementation

--- a/build.rs
+++ b/build.rs
@@ -20,6 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // uProtocol-project proto definitions
         format!("{}uprotocol/uoptions.proto", UPROTOCOL_BASE_URI),
         // [impl->req~uuid-proto~1]
+        // [impl->req~uuid-type~1]
         format!("{}uprotocol/v1/uuid.proto", UPROTOCOL_BASE_URI),
         // [impl->req~uri-data-model-proto~1]
         format!("{}uprotocol/v1/uri.proto", UPROTOCOL_BASE_URI),

--- a/src/core/udiscovery.rs
+++ b/src/core/udiscovery.rs
@@ -52,7 +52,7 @@ pub fn udiscovery_uri(resource_id: u16) -> UUri {
 
 /// The uProtocol Application Layer client interface to the uDiscovery service.
 ///
-/// Please refer to the [uDiscovery service specification](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.4/up-l3/udiscovery/v3/client.adoc)
+/// Please refer to the [uDiscovery service specification](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.5/up-l3/udiscovery/v3/client.adoc)
 /// for details.
 #[cfg_attr(test, automock)]
 #[async_trait]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,14 @@
  ********************************************************************************/
 
 /*!
-up-rust is the [Eclipse uProtocol&trade; Language Library](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.4/languages.adoc) for the
+up-rust is the [Eclipse uProtocol&trade; Language Library](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.5/languages.adoc) for the
 Rust programming language.
 
 This crate can be used to
 
-* implement uEntities that communicate with each other using the uProtocol [Communication Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.4/up-l2/api.adoc)
+* implement uEntities that communicate with each other using the uProtocol [Communication Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.5/up-l2/api.adoc)
   over one of the supported transport protocols.
-* implement support for an additional transport protocol by means of implementing the [Transport Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.4/up-l1/README.adoc).
+* implement support for an additional transport protocol by means of implementing the [Transport Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.5/up-l1/README.adoc).
 
 ## Library contents
 
@@ -38,23 +38,23 @@ For user convenience, all of these modules export their types on up_rust top-lev
 ## Features
 
 * `cloudevents` enables support for mapping UMessages to/from CloudEvents using Protobuf Format according to the
-  [uProtocol specification](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.4/up-l1/cloudevents.adoc).
+  [uProtocol specification](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.5/up-l1/cloudevents.adoc).
 
-* `communication` enables support for the [Communication Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.4/up-l2/api.adoc) and its
-  default implementation on top of the [Transport Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.4/up-l1/README.adoc).
+* `communication` enables support for the [Communication Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.5/up-l2/api.adoc) and its
+  default implementation on top of the [Transport Layer API](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.5/up-l1/README.adoc).
   Enabled by default.
-* `udiscovery` enables support for types required to interact with [uDiscovery service](https://raw.githubusercontent.com/eclipse-uprotocol/up-spec/v1.6.0-alpha.4/up-l3/udiscovery/v3/README.adoc)
+* `udiscovery` enables support for types required to interact with [uDiscovery service](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.5/up-l3/udiscovery/v3/README.adoc)
   implementations.
-* `usubscription` enables support for types required to interact with [uSubscription service](https://raw.githubusercontent.com/eclipse-uprotocol/up-spec/v1.6.0-alpha.4/up-l3/usubscription/v3/README.adoc)
+* `usubscription` enables support for types required to interact with [uSubscription service](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.5/up-l3/usubscription/v3/README.adoc)
   implementations. Enabled by default.
-* `utwin` enables support for types required to interact with [uTwin service](https://raw.githubusercontent.com/eclipse-uprotocol/up-spec/v1.6.0-alpha.4/up-l3/utwin/v3/README.adoc)
+* `utwin` enables support for types required to interact with [uTwin service](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.5/up-l3/utwin/v2/README.adoc)
   implementations.
 * `test-util` provides some useful mock implementations for testing. In particular, provides mock implementations of UTransport and Communication Layer API traits which make implementing unit tests a lot easier.
 * `util` provides some useful helper structs. In particular, provides a local, in-memory UTransport for exchanging messages within a single process. This transport is also used by the examples illustrating usage of the Communication Layer API.
 
 ## References
 
-* [uProtocol Specification](https://github.com/eclipse-uprotocol/up-spec/tree/v1.6.0-alpha.4)
+* [uProtocol Specification](https://github.com/eclipse-uprotocol/up-spec/tree/v1.6.0-alpha.5)
 
 */
 

--- a/src/utransport.rs
+++ b/src/utransport.rs
@@ -185,7 +185,7 @@ impl TryFrom<&UUri> for StaticUriProvider {
 ///
 /// Implementations contain the details for what should occur when a message is received.
 ///
-/// Please refer to the [uProtocol Transport Layer specification](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.4/up-l1/README.adoc)
+/// Please refer to the [uProtocol Transport Layer specification](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.5/up-l1/README.adoc)
 /// for details.
 // [impl->req~up-language-transport-api~1]
 #[cfg_attr(any(test, feature = "test-util"), mockall::automock)]
@@ -211,7 +211,7 @@ pub trait UListener: Send + Sync {
 /// Implementations contain the details for connecting to the underlying transport technology and
 /// sending [`UMessage`]s using the configured technology.
 ///
-/// Please refer to the [uProtocol Transport Layer specification](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.4/up-l1/README.adoc)
+/// Please refer to the [uProtocol Transport Layer specification](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.5/up-l1/README.adoc)
 /// for details.
 // [impl->req~up-language-transport-api~1]
 #[async_trait]
@@ -221,7 +221,7 @@ pub trait UTransport: Send + Sync {
     /// # Arguments
     ///
     /// * `message` - The message to send. The `type`, `source` and `sink` properties of the
-    ///   [UAttributes](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.4/basics/uattributes.adoc) contained
+    ///   [UAttributes](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.5/basics/uattributes.adoc) contained
     ///   in the message determine the addressing semantics.
     ///
     /// # Errors
@@ -256,7 +256,7 @@ pub trait UTransport: Send + Sync {
     /// Registers a listener to be called for messages.
     ///
     /// The listener will be invoked for each message that matches the given source and sink filter patterns
-    /// according to the rules defined by the [UUri specification](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.4/basics/uri.adoc).
+    /// according to the rules defined by the [UUri specification](https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.5/basics/uri.adoc).
     ///
     /// This default implementation returns an error with [`UCode::UNIMPLEMENTED`].
     ///


### PR DESCRIPTION
Adapted all URLs in source and docs accordingly.
Updated "current" OFT tracing configuration to reflect new baseline.