### PR TITLE
Update submodule URL to https auth

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "up-spec"]
 	path = up-spec
-	url = git@github.com:eclipse-uprotocol/up-spec
+	url = https://github.com/eclipse-uprotocol/up-spec.git


### PR DESCRIPTION
Test PR, to makes dependent components (like up-subscription-rust) build again.

For some reason, the git: authentication method now fails when building up-rust in the context of dependent projects.