### PR TITLE
Fix message expiration check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,7 +1526,7 @@ checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "up-rust"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ name = "up-rust"
 readme = "README.md"
 repository = "https://github.com/eclipse-uprotocol/up-rust"
 rust-version = "1.82"
-version = "0.7.0"
+version = "0.7.1"
 
 [features]
 default = ["communication"]

--- a/src/uattributes.rs
+++ b/src/uattributes.rs
@@ -140,29 +140,46 @@ impl UAttributes {
     /// # Errors
     ///
     /// Returns an error if [`Self::ttl`] (time-to-live) contains a value greater than 0, but
-    /// * the message has expired according to the timestamp extracted from [`Self::id`] and the time-to-live value, or
-    /// * the current system time cannot be determined.
+    /// * the current system time cannot be determined, or
+    /// * the message has expired according to the timestamp extracted from [`Self::id`] and the time-to-live value.
     pub fn check_expired(&self) -> Result<(), UAttributesError> {
+        if let Some(ttl) = self.ttl {
+            if ttl == 0 {
+                return Ok(());
+            }
+        }
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_err(|_e| {
+                UAttributesError::validation_error("Cannot determine current system time")
+            })
+            .and_then(|duration_since_epoch| {
+                self.check_expired_for_reference(duration_since_epoch.as_millis())
+            })
+    }
+
+    /// Checks if the message that is described by these attributes should be considered expired.
+    ///
+    /// # Arguments
+    /// * `reference_time` - The reference time as a `Duration` since UNIX epoch. The check will be performed in relation to this point in time.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if [`Self::ttl`] (time-to-live) contains a value greater than 0, but
+    /// the message has expired according to the timestamp extracted from [`Self::id`], the
+    /// time-to-live value and the provided reference time.
+    pub fn check_expired_for_reference(
+        &self,
+        reference_time: u128,
+    ) -> Result<(), UAttributesError> {
         let ttl = match self.ttl {
-            Some(t) if t > 0 => u64::from(t),
+            Some(t) if t > 0 => u128::from(t),
             _ => return Ok(()),
         };
 
         if let Some(creation_time) = self.id.as_ref().and_then(UUID::get_time) {
-            let delta = match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-                Ok(duration) => {
-                    if let Ok(duration) = u64::try_from(duration.as_millis()) {
-                        duration - creation_time
-                    } else {
-                        return Err(UAttributesError::validation_error(
-                            "Invalid system time: too far in the future",
-                        ));
-                    }
-                }
-                Err(e) => return Err(UAttributesError::validation_error(e.to_string())),
-            };
-            if delta >= ttl {
-                return Err(UAttributesError::validation_error("message is expired"));
+            if (creation_time as u128).saturating_add(ttl) <= reference_time {
+                return Err(UAttributesError::validation_error("Message has expired"));
             }
         }
         Ok(())
@@ -171,33 +188,37 @@ impl UAttributes {
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Sub;
-    use std::time::{Duration, UNIX_EPOCH};
+    use std::time::UNIX_EPOCH;
 
     use super::*;
     use test_case::test_case;
 
-    /// Creates a UUID n ms in the past.
+    /// Creates a UUID for a given creation time offset.
     ///
     /// # Note
     ///
     /// For internal testing purposes only. For end-users, please use [`UUID::build()`]
-    fn build_n_ms_in_past(n_ms_in_past: u64) -> UUID {
+    fn build_for_time_offset(offset_millis: i64) -> UUID {
         let duration_since_unix_epoch = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("current system time is set to a point in time before UNIX Epoch");
-        UUID::build_for_timestamp(
-            duration_since_unix_epoch.sub(Duration::from_millis(n_ms_in_past)),
-        )
+        let now_as_millis_since_epoch: u64 = u64::try_from(duration_since_unix_epoch.as_millis())
+            .expect("current system time is too far in the future");
+        let creation_timestamp = now_as_millis_since_epoch
+            .checked_add_signed(offset_millis)
+            .unwrap();
+        UUID::build_for_timestamp_millis(creation_timestamp)
     }
 
     #[test_case(None, None, false; "for message without ID nor TTL")]
     #[test_case(None, Some(0), false; "for message without ID with TTL 0")]
     #[test_case(None, Some(500), false; "for message without ID with TTL")]
-    #[test_case(Some(build_n_ms_in_past(1000)), None, false; "for message with ID without TTL")]
-    #[test_case(Some(build_n_ms_in_past(1000)), Some(0), false; "for message with ID and TTL 0")]
-    #[test_case(Some(build_n_ms_in_past(1000)), Some(500), true; "for message with ID and expired TTL")]
-    #[test_case(Some(build_n_ms_in_past(1000)), Some(2000), false; "for message with ID and non-expired TTL")]
+    #[test_case(Some(build_for_time_offset(-1000)), None, false; "for past message without TTL")]
+    #[test_case(Some(build_for_time_offset(-1000)), Some(0), false; "for past message with TTL 0")]
+    #[test_case(Some(build_for_time_offset(-1000)), Some(500), true; "for past message with expired TTL")]
+    #[test_case(Some(build_for_time_offset(-1000)), Some(2000), false; "for past message with non-expired TTL")]
+    #[test_case(Some(build_for_time_offset(1000)), Some(2000), false; "for future message with TTL")]
+    #[test_case(Some(build_for_time_offset(1000)), None, false; "for future message without TTL")]
     fn test_is_expired(id: Option<UUID>, ttl: Option<u32>, should_be_expired: bool) {
         let attributes = UAttributes {
             type_: UMessageType::UMESSAGE_TYPE_NOTIFICATION.into(),

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -129,6 +129,11 @@ impl UUID {
     pub(crate) fn build_for_timestamp(duration_since_unix_epoch: Duration) -> UUID {
         let timestamp_millis = u64::try_from(duration_since_unix_epoch.as_millis())
             .expect("system time is set to a time too far in the future");
+        Self::build_for_timestamp_millis(timestamp_millis)
+    }
+
+    // [impl->dsn~uuid-spec~1]
+    pub(crate) fn build_for_timestamp_millis(timestamp_millis: u64) -> UUID {
         // fill upper 48 bits with timestamp
         let mut msb = (timestamp_millis << 16).to_be_bytes();
         // fill remaining bits with random bits


### PR DESCRIPTION
The message expiration check has been updated to properly consider
creation timestamps that lie in the future relative to the
local system time.

Fixes #278