### PR TITLE
Make helper function public for external use.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,7 +1533,7 @@ checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "up-rust"
-version = "0.8.0"
+version = "0.8.1-SNAPSHOT"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ name = "up-rust"
 readme = "README.md"
 repository = "https://github.com/eclipse-uprotocol/up-rust"
 rust-version = "1.82"
-version = "0.8.0"
+version = "0.8.1-SNAPSHOT"
 
 [features]
 default = ["communication"]

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -457,9 +457,26 @@ impl UUri {
         (self.resource_id & WILDCARD_RESOURCE_ID) as u16
     }
 
+    /// Verifies that the given authority name complies with the UUri specification.
+    ///
+    /// # Arguments
+    ///
+    /// * `authority` - The authority name to verify.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the authority name is invalid.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use up_rust::UUri;
+    ///
+    /// assert!(UUri::verify_authority("my.vin").is_ok());
+    /// ```
     // [impl->dsn~uri-authority-name-length~1]
     // [impl->dsn~uri-host-only~2]
-    pub(crate) fn verify_authority(authority: &str) -> Result<String, UUriError> {
+    pub fn verify_authority(authority: &str) -> Result<String, UUriError> {
         Authority::try_from(authority)
             .map_err(|e| UUriError::validation_error(format!("invalid authority: {e}")))
             .and_then(|auth| Self::verify_parsed_authority(&auth))


### PR DESCRIPTION
Made the UUri::verify_authority method public so that external
code can utilize it for URI authority verification.

This is particularly useful for transport implementations that are
created with a local authority to fall back to when source UUris
without authority are being used by client code.