### PR TITLE
Prepare v0.8.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,7 +1533,7 @@ checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "up-rust"
-version = "0.8.1-SNAPSHOT"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ name = "up-rust"
 readme = "README.md"
 repository = "https://github.com/eclipse-uprotocol/up-rust"
 rust-version = "1.82"
-version = "0.8.1-SNAPSHOT"
+version = "0.8.1"
 
 [features]
 default = ["communication"]


### PR DESCRIPTION
I would like to create the 0.8.1 patch release in order to be able to use the newly exposed helper function in the Rust based transports when updating them to the latest spec version.