### PR TITLE
Add support for implementing Symphony Targets as uEntities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -119,6 +119,15 @@ name = "bitflags"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -186,7 +195,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -215,6 +224,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +256,16 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "cucumber"
@@ -281,7 +309,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.96",
+ "syn 2.0.110",
  "synthez",
 ]
 
@@ -327,7 +355,17 @@ checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -444,7 +482,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -475,6 +513,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -511,7 +559,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.96",
+ "syn 2.0.110",
  "textwrap",
  "thiserror",
  "typed-builder",
@@ -680,7 +728,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.96",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -694,6 +742,16 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -769,7 +827,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -791,6 +849,15 @@ dependencies = [
  "bytecount",
  "memchr",
  "nom",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -864,7 +931,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1195,39 +1262,70 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1240,6 +1338,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "smart-default"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,7 +1351,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1272,6 +1376,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "symphony"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c1034fde5cc8c9c038734f1b422492f7cc15006dfebc11aa04ba418d1b63f4"
+dependencies = [
+ "libloading",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1299,7 +1417,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d2c2202510a1e186e63e596d9318c91a8cbe85cd1a56a7be0c333e5f59ec8d"
 dependencies = [
- "syn 2.0.96",
+ "syn 2.0.110",
  "synthez-codegen",
  "synthez-core",
 ]
@@ -1310,7 +1428,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f724aa6d44b7162f3158a57bccd871a77b39a4aef737e01bcdff41f4772c7746"
 dependencies = [
- "syn 2.0.96",
+ "syn 2.0.110",
  "synthez-core",
 ]
 
@@ -1323,7 +1441,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sealed",
- "syn 2.0.96",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1374,7 +1492,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1385,7 +1503,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.110",
  "test-case-core",
 ]
 
@@ -1417,7 +1535,16 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1470,7 +1597,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1481,7 +1608,19 @@ checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1491,6 +1630,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1510,8 +1675,14 @@ checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.110",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
@@ -1533,7 +1704,7 @@ checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "up-rust"
-version = "0.8.1"
+version = "0.9.0-SNAPSHOT"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1547,6 +1718,9 @@ dependencies = [
  "protoc-bin-vendored",
  "rand",
  "regex",
+ "serde",
+ "serde_json",
+ "symphony",
  "test-case",
  "thiserror",
  "tokio",
@@ -1580,6 +1754,18 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vsimd"
@@ -1641,6 +1827,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -1751,5 +1943,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.110",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ name = "up-rust"
 readme = "README.md"
 repository = "https://github.com/eclipse-uprotocol/up-rust"
 rust-version = "1.82"
-version = "0.8.1"
+version = "0.9.0-SNAPSHOT"
 
 [features]
 default = ["communication"]
@@ -41,6 +41,7 @@ usubscription = []
 utwin = []
 util = ["tokio/sync"]
 test-util = ["mockall"]
+symphony = ["communication", "dep:serde", "dep:serde_json", "dep:symphony"]
 
 [dependencies]
 async-trait = { version = "0.1" }
@@ -50,6 +51,9 @@ mockall = { version = "0.13", optional = true }
 protobuf = { version = "3.7.2", features = ["with-bytes"] }
 rand = { version = "0.9" }
 regex = { version = "1.11" }
+serde = { version = "1.0.228", optional = true }
+serde_json = { version = "1.0.145", optional = true }
+symphony = { version = "0.1", optional = true }
 thiserror = { version = "1.0.69", optional = true }
 tokio = { version = "1.45.1", default-features = false, optional = true }
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }

--- a/deny.toml
+++ b/deny.toml
@@ -16,7 +16,7 @@
 
 # If you add a license in the following section also consider changing about.toml
 [licenses]
-allow = ["Apache-2.0", "MIT"]
+allow = ["Apache-2.0", "ISC", "MIT"]
 private = { ignore = true }
 exceptions = [{ name = "unicode-ident", allow = ["Unicode-3.0"] }]
 unused-allowed-license = "deny"

--- a/src/communication/in_memory_rpc_server.rs
+++ b/src/communication/in_memory_rpc_server.rs
@@ -40,13 +40,18 @@ impl RequestListener {
         let mut response_builder =
             UMessageBuilder::response_for_request(request_message.attributes_unchecked());
 
-        let request_message_id = request_message.id_unchecked().clone();
+        let request_message_id = request_message.id_unchecked().to_hyphenated_string();
         let request_timeout = request_message.ttl_unchecked();
         let payload_format = request_message.payload_format().unwrap_or_default();
         let payload = request_message.payload;
         let request_payload = payload.map(|data| UPayload::new(data, payload_format));
 
-        debug!(ttl = request_timeout, id = %request_message_id, "processing RPC request");
+        debug!(
+            ttl = request_timeout,
+            id = request_message_id,
+            resource_id = resource_id,
+            "processing RPC request"
+        );
 
         let invocation_result_future = request_handler_clone.handle_request(
             resource_id,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ For user convenience, all of these modules export their types on up_rust top-lev
   implementations.
 * `test-util` provides some useful mock implementations for testing. In particular, provides mock implementations of UTransport and Communication Layer API traits which make implementing unit tests a lot easier.
 * `util` provides some useful helper structs. In particular, provides a local, in-memory UTransport for exchanging messages within a single process. This transport is also used by the examples illustrating usage of the Communication Layer API.
+* `symphony` enables support for implementing an [Eclipse Symphony](https://github.com/eclipse-symphony) Target Provider as a uService exposed via the Communication Layer API's `RpcServer`.
 
 ## References
 
@@ -70,6 +71,9 @@ pub mod communication;
 
 #[cfg(feature = "util")]
 pub mod local_transport;
+
+#[cfg(feature = "symphony")]
+pub mod symphony;
 
 mod uattributes;
 pub use uattributes::{

--- a/src/symphony.rs
+++ b/src/symphony.rs
@@ -1,0 +1,435 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+/*!
+Types and helpers that allow implementing an Eclipse Symphony&trade; Target Provider as a uService
+exposed via the Communication Layer API's `RpcServer`.
+*/
+
+use std::{collections::HashMap, sync::Arc};
+
+use async_trait::async_trait;
+use serde_json::Value;
+use symphony::models::{ComponentResultSpec, ComponentSpec, DeploymentSpec};
+use tracing::{debug, error, trace, warn, Level};
+
+use crate::{
+    communication::{RequestHandler, RpcServer, ServiceInvocationError, UPayload},
+    UAttributes, UPayloadFormat,
+};
+
+pub const METHOD_GET_RESOURCE_ID: u16 = 0x0001;
+pub const METHOD_UPDATE_RESOURCE_ID: u16 = 0x0002;
+pub const METHOD_DELETE_RESOURCE_ID: u16 = 0x0003;
+
+/// Registers RPC endpoints for managing a deployment target via Eclipse Symphony's uProtocol
+/// Target Provider.
+///
+/// This function registers three RPC endpoints that delegate to the provided [`DeploymentTarget`] implementation:
+/// - `Get` (resource ID `0x0001`) - Retrieves current component status
+/// - `Update` (resource ID `0x0002`) - Updates deployment components  
+/// - `Delete` (resource ID `0x0003`) - Removes deployment components
+///
+/// # Arguments
+/// * `rpc_server` - The RPC server to register the endpoints on
+/// * `deployment_target` - The deployment target implementation to delegate requests to
+///
+/// # Errors
+/// Returns an error if any of the endpoints cannot be registered on the RPC server.
+pub async fn register_target_provider_endpoints<R: RpcServer, T: DeploymentTarget + 'static>(
+    rpc_server: &R,
+    deployment_target: Arc<T>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let get_op = Arc::new(GetOperation {
+        target: deployment_target.clone(),
+    });
+    let apply_op = Arc::new(ApplyOperation {
+        target: deployment_target,
+    });
+    rpc_server
+        .register_endpoint(None, METHOD_GET_RESOURCE_ID, get_op)
+        .await
+        .inspect_err(|e| error!("failed to register Get operation on RPC Server: {e}"))?;
+    rpc_server
+        .register_endpoint(None, METHOD_UPDATE_RESOURCE_ID, apply_op.clone())
+        .await
+        .inspect_err(|e| error!("failed to register Update operation on RPC Server: {e}"))?;
+    rpc_server
+        .register_endpoint(None, METHOD_DELETE_RESOURCE_ID, apply_op)
+        .await
+        .inspect_err(|e| error!("failed to register Delete operation on RPC Server: {e}"))?;
+    Ok(())
+}
+
+#[cfg_attr(any(test, feature = "test-util"), mockall::automock)]
+#[async_trait]
+pub trait DeploymentTarget: Send + Sync {
+    /// Retrieves the current status of components within a deployment.
+    ///
+    /// # Arguments
+    /// * `components` - The components whose current status should be retrieved
+    /// * `deployment_spec` - The deployment context containing these components
+    ///
+    /// # Returns
+    /// A vector of [`ComponentSpec`] representing the currently deployed state of the requested components.
+    ///
+    /// # Errors
+    /// Returns an error if the current deployment status cannot be determined.
+    async fn get(
+        &self,
+        components: Vec<ComponentSpec>,
+        deployment_spec: DeploymentSpec,
+    ) -> Result<Vec<ComponentSpec>, Box<dyn std::error::Error>>;
+
+    /// Updates the specified components within a deployment.
+    ///
+    /// # Arguments
+    /// * `components_to_update` - The components to be updated
+    /// * `deployment_spec` - The deployment context for these components
+    ///
+    /// # Returns
+    /// A map where keys are component identifiers and values are [`ComponentResultSpec`]
+    /// indicating the outcome of each component's update operation.
+    ///
+    /// # Errors
+    /// Returns an error if the update operation cannot be performed. Individual component
+    /// failures should be reported in the returned map rather than as an overall error.
+    async fn update(
+        &self,
+        components_to_update: Vec<ComponentSpec>,
+        deployment_spec: DeploymentSpec,
+    ) -> Result<HashMap<String, ComponentResultSpec>, Box<dyn std::error::Error>>;
+
+    /// Removes the specified components from a deployment.
+    ///
+    /// # Arguments
+    /// * `components_to_delete` - The components to be removed
+    /// * `deployment_spec` - The deployment context for these components
+    ///
+    /// # Returns
+    /// A map where keys are component identifiers and values are [`ComponentResultSpec`]
+    /// indicating the outcome of each component's deletion operation.
+    ///
+    /// # Errors
+    /// Returns an error if the delete operation cannot be performed. Individual component
+    /// failures should be reported in the returned map rather than as an overall error.
+    async fn delete(
+        &self,
+        components_to_delete: Vec<ComponentSpec>,
+        deployment_spec: DeploymentSpec,
+    ) -> Result<HashMap<String, ComponentResultSpec>, Box<dyn std::error::Error>>;
+}
+
+fn extract_request_data(
+    request_payload: Option<UPayload>,
+) -> Result<Value, ServiceInvocationError> {
+    let Some(req_payload) = request_payload
+        .filter(|req_payload| req_payload.payload_format() == UPayloadFormat::UPAYLOAD_FORMAT_JSON)
+    else {
+        return Err(ServiceInvocationError::InvalidArgument(
+            "request has no JSON payload".to_string(),
+        ));
+    };
+
+    serde_json::from_slice(req_payload.payload().to_vec().as_slice()).map_err(|err| {
+        debug!("failed to deserialize request payload: {:?}", err);
+        ServiceInvocationError::InvalidArgument(
+            "request payload is not a valid UTF-8 string".to_string(),
+        )
+    })
+}
+
+struct GetOperation<T: DeploymentTarget> {
+    target: Arc<T>,
+}
+
+#[async_trait::async_trait]
+impl<T: DeploymentTarget> RequestHandler for GetOperation<T> {
+    // expects a DeploymentSpec in the request and returns an array of ComponentSpecs
+    async fn handle_request(
+        &self,
+        _resource_id: u16,
+        message_attributes: &UAttributes,
+        request_payload: Option<UPayload>,
+    ) -> Result<Option<UPayload>, ServiceInvocationError> {
+        let source_uri = message_attributes.source_unchecked().to_uri(true);
+        if tracing::enabled!(Level::DEBUG) {
+            debug!(source = source_uri, "processing GET request");
+        }
+        let request_data = extract_request_data(request_payload)?;
+        if tracing::enabled!(Level::TRACE) {
+            trace!(
+                source = source_uri,
+                "payload: {}",
+                serde_json::to_string_pretty(&request_data).expect("failed to serialize Value")
+            );
+        }
+        let deployment_spec: DeploymentSpec =
+            serde_json::from_value(request_data["deployment"].clone()).map_err(|err| {
+                debug!(
+                    source = source_uri,
+                    "request does not contain DeploymentSpec: {err}"
+                );
+                ServiceInvocationError::InvalidArgument(
+                    "request does not contain DeploymentSpec".to_string(),
+                )
+            })?;
+        let component_specs: Vec<ComponentSpec> =
+            serde_json::from_value(request_data["components"].clone()).map_err(|err| {
+                debug!(
+                    source = source_uri,
+                    "request does not contain ComponentSpec array: {err}"
+                );
+                ServiceInvocationError::InvalidArgument(
+                    "request does not contain ComponentSpec array".to_string(),
+                )
+            })?;
+
+        let result = self
+            .target
+            .get(component_specs, deployment_spec)
+            .await
+            .map_err(|err| {
+                warn!(source = source_uri, "error getting component status: {err}");
+                ServiceInvocationError::Internal("failed to get component status".to_string())
+            })?;
+        let serialized_response_data = serde_json::to_vec(&result).map_err(|err| {
+            warn!(
+                source = source_uri,
+                "error serializing ComponentSpec: {err}"
+            );
+            ServiceInvocationError::Internal("failed to create response payload".to_string())
+        })?;
+        if tracing::enabled!(Level::TRACE) {
+            trace!(
+                source = source_uri,
+                "returning response: {}",
+                serde_json::to_string_pretty(&result).expect("failed to serialize Value")
+            );
+        }
+        let response_payload = UPayload::new(
+            serialized_response_data,
+            UPayloadFormat::UPAYLOAD_FORMAT_JSON,
+        );
+        Ok(Some(response_payload))
+    }
+}
+
+struct ApplyOperation<T: DeploymentTarget> {
+    target: Arc<T>,
+}
+
+#[async_trait::async_trait]
+impl<T: DeploymentTarget> RequestHandler for ApplyOperation<T> {
+    async fn handle_request(
+        &self,
+        resource_id: u16,
+        message_attributes: &UAttributes,
+        request_payload: Option<UPayload>,
+    ) -> Result<Option<UPayload>, ServiceInvocationError> {
+        let source_uri = message_attributes.source_unchecked().to_uri(true);
+        let sink_uri = message_attributes.sink_unchecked().to_uri(true);
+        if tracing::enabled!(Level::DEBUG) {
+            debug!(source = source_uri, method = sink_uri, "processing request",);
+        }
+        let request_data = extract_request_data(request_payload)?;
+        if tracing::enabled!(Level::TRACE) {
+            let json =
+                serde_json::to_string_pretty(&request_data).expect("failed to serialize Value");
+            trace!("payload: {}", json);
+        }
+
+        let deployment_spec: DeploymentSpec =
+            serde_json::from_value(request_data["deployment"].clone()).map_err(|err| {
+                debug!(
+                    source = source_uri,
+                    method = sink_uri,
+                    "request does not contain DeploymentSpec: {err}"
+                );
+                ServiceInvocationError::InvalidArgument(
+                    "request does not contain DeploymentSpec".to_string(),
+                )
+            })?;
+
+        let affected_components: Vec<ComponentSpec> =
+            serde_json::from_value(request_data["components"].clone()).map_err(|err| {
+                debug!(
+                    source = source_uri,
+                    method = sink_uri,
+                    "request does not contain ComponentSpec array: {err}"
+                );
+                ServiceInvocationError::InvalidArgument(
+                    "request does not contain ComponentSpec array".to_string(),
+                )
+            })?;
+
+        let result = match resource_id {
+            METHOD_UPDATE_RESOURCE_ID => self
+                .target
+                .update(affected_components, deployment_spec)
+                .await
+                .map_err(|err| {
+                    warn!(
+                        source = source_uri,
+                        method = sink_uri,
+                        "error updating components: {err}"
+                    );
+                    ServiceInvocationError::Internal("failed to update components".to_string())
+                }),
+            METHOD_DELETE_RESOURCE_ID => self
+                .target
+                .delete(affected_components, deployment_spec)
+                .await
+                .map_err(|err| {
+                    warn!(
+                        source = source_uri,
+                        method = sink_uri,
+                        "error deleting components: {err}"
+                    );
+                    ServiceInvocationError::Internal("failed to delete components".to_string())
+                }),
+            _ => {
+                return Err(ServiceInvocationError::Unimplemented(
+                    "no such operation".to_string(),
+                ));
+            }
+        }?;
+
+        let serialized_response_data = serde_json::to_vec(&result).map_err(|err| {
+            warn!(
+                source = source_uri,
+                method = sink_uri,
+                "error serializing HashMap: {err}"
+            );
+            ServiceInvocationError::Internal("failed to create response payload".to_string())
+        })?;
+
+        let response_payload = UPayload::new(
+            serialized_response_data,
+            UPayloadFormat::UPAYLOAD_FORMAT_JSON,
+        );
+        Ok(Some(response_payload))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use serde_json::json;
+    use tokio::sync::Notify;
+
+    use crate::{
+        communication::{
+            CallOptions, InMemoryRpcClient, InMemoryRpcServer, MockRpcServerImpl, RpcClient,
+        },
+        local_transport::LocalTransport,
+        StaticUriProvider, UUri,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_register_target_provider_endpoints_fails() {
+        let mut rpc_server = MockRpcServerImpl::new();
+        rpc_server
+            .expect_do_register_endpoint()
+            .returning(|_, _, _| {
+                Err(crate::communication::RegistrationError::MaxListenersExceeded)
+            });
+        let deployment_target = MockDeploymentTarget::new();
+
+        assert!(
+            register_target_provider_endpoints(&rpc_server, Arc::new(deployment_target))
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_endpoints_delegate_to_deployment_target() {
+        let transport = Arc::new(LocalTransport::default());
+
+        let get_method =
+            UUri::try_from_parts("local_authority", 0xAAA1, 0x01, METHOD_GET_RESOURCE_ID)
+                .expect("failed to create get method URI");
+        let update_method =
+            UUri::try_from_parts("local_authority", 0xAAA1, 0x01, METHOD_UPDATE_RESOURCE_ID)
+                .expect("failed to create update method URI");
+        let delete_method =
+            UUri::try_from_parts("local_authority", 0xAAA1, 0x01, METHOD_DELETE_RESOURCE_ID)
+                .expect("failed to create delete method URI");
+        let uri_provider =
+            StaticUriProvider::try_from(&get_method).expect("failed to create URI provider");
+        let rpc_server = InMemoryRpcServer::new(transport.clone(), Arc::new(uri_provider));
+
+        let mut mock_target = MockDeploymentTarget::default();
+        let get_notify = Arc::new(Notify::new());
+        let cloned_get_notify = get_notify.clone();
+        mock_target.expect_get().returning(move |_, _| {
+            cloned_get_notify.notify_one();
+            Ok(vec![])
+        });
+        let update_notify = Arc::new(Notify::new());
+        let cloned_update_notify = update_notify.clone();
+        mock_target.expect_update().returning(move |_, _| {
+            cloned_update_notify.notify_one();
+            Ok(HashMap::new())
+        });
+        let delete_notify = Arc::new(Notify::new());
+        let cloned_delete_notify = delete_notify.clone();
+        mock_target.expect_delete().returning(move |_, _| {
+            cloned_delete_notify.notify_one();
+            Ok(HashMap::new())
+        });
+        register_target_provider_endpoints(&rpc_server, Arc::new(mock_target))
+            .await
+            .expect("failed to register endpoints");
+
+        let rpc_client = InMemoryRpcClient::new(
+            transport.clone(),
+            Arc::new(StaticUriProvider::new("local_authority", 0xAAA2, 0x01)),
+        )
+        .await
+        .expect("failed to create RPC client");
+
+        let request_payload = json!({
+            "deployment": DeploymentSpec::empty(),
+            "components": []
+        });
+        let payload = UPayload::new(
+            serde_json::to_vec(&request_payload).expect("failed to create request payload"),
+            UPayloadFormat::UPAYLOAD_FORMAT_JSON,
+        );
+        let call_options = CallOptions::for_rpc_request(0x1000, None, None, None);
+        rpc_client
+            .invoke_method(get_method, call_options.clone(), Some(payload.clone()))
+            .await
+            .expect("Get invocation failed");
+        rpc_client
+            .invoke_method(update_method, call_options.clone(), Some(payload.clone()))
+            .await
+            .expect("Update invocation failed");
+        rpc_client
+            .invoke_method(delete_method, call_options, Some(payload))
+            .await
+            .expect("Delete invocation failed");
+
+        tokio::try_join!(
+            tokio::time::timeout(Duration::from_secs(2), get_notify.notified()),
+            tokio::time::timeout(Duration::from_secs(2), update_notify.notified()),
+            tokio::time::timeout(Duration::from_secs(2), delete_notify.notified()),
+        )
+        .expect("failed to receive notification from deployment target");
+    }
+}

--- a/src/umessage/umessagebuilder.rs
+++ b/src/umessage/umessagebuilder.rs
@@ -574,7 +574,7 @@ impl UMessageBuilder {
     ///
     /// # Examples
     ///
-    /// ## Not setting `id` explicitly with [`UMessageBuilder::with_message_id()']
+    /// ## Not setting `id` explicitly with [`UMessageBuilder::with_message_id`]
     ///
     /// The recommended way to use the `UMessageBuilder`.
     ///
@@ -593,9 +593,9 @@ impl UMessageBuilder {
     /// # }
     /// ```
     ///
-    /// ## Setting `id` explicitly with [`UMessageBuilder::with_message_id()']
+    /// ## Setting `id` explicitly with [`UMessageBuilder::with_message_id`]
     ///
-    /// Note that explicitly using [`UMessageBuilder::with_message_id()'] is not required as shown
+    /// Note that explicitly using [`UMessageBuilder::with_message_id`] is not required as shown
     /// above.
     ///
     /// ```rust


### PR DESCRIPTION
Added some helper structs and traits to facilitate implementing
Symphony Targets as uEntities.

The types are guarded behind the "symphony" feature flag.