### PR TITLE
Updated CICD workflows to use latest shared artifacts

### DIFF
--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -42,6 +42,6 @@ jobs:
           | sed -E 's|([^ ]+) v([^ ]+).*|crate/cratesio/-/\1/\2|' \
           > DEPS.txt
     - name: Run Eclipse Dash Licenses tool
-      uses: eclipse-uprotocol/ci-cd/.github/actions/run-eclipse-dash@c9fb74b20429e69c15021c64dcf343447a2f46a2 # main
+      uses: eclipse-uprotocol/ci-cd/.github/actions/run-eclipse-dash@fcaf488b5d152c290a3a8dca2463a5c1dec65acd # main
       with:
         components-file: DEPS.txt

--- a/.github/workflows/latest-up-spec-compatibility.yaml
+++ b/.github/workflows/latest-up-spec-compatibility.yaml
@@ -59,7 +59,7 @@ jobs:
       # a tracing report
       - name: Run OpenFastTrace
         id: run-oft
-        uses: eclipse-uprotocol/ci-cd/.github/actions/run-oft@c9fb74b20429e69c15021c64dcf343447a2f46a2 # main
+        uses: eclipse-uprotocol/ci-cd/.github/actions/run-oft@fcaf488b5d152c290a3a8dca2463a5c1dec65acd # main
         with:
           file-patterns: "${{ env.OFT_FILE_PATTERNS }}"
           tags: "${{ env.OFT_TAGS_}}"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -27,28 +27,28 @@ concurrency:
 
 jobs:
   check-msrv:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-verify-msrv.yaml@c9fb74b20429e69c15021c64dcf343447a2f46a2 # main
+    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-verify-msrv.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd # main
 
   check-latest-deps:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-verify-latest-deps.yaml@c9fb74b20429e69c15021c64dcf343447a2f46a2 # main
+    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-verify-latest-deps.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd # main
 
   deny:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-deny-check.yaml@c9fb74b20429e69c15021c64dcf343447a2f46a2 # main
+    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-deny-check.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd # main
     with:
       arguments: --all-features --locked --exclude-dev
 
   # [impl->req~up-language-ci-test~1]
   test-all-features:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-test-featurematrix.yaml@c9fb74b20429e69c15021c64dcf343447a2f46a2 # main
+    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-test-featurematrix.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd # main
 
   x-build:
     # The jury is still out on whether this actually adds any value, besides simply being possible...
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-x-build.yaml@c9fb74b20429e69c15021c64dcf343447a2f46a2 # main
+    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-x-build.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd # main
 
   coverage:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-coverage.yaml@c9fb74b20429e69c15021c64dcf343447a2f46a2 # main
+    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-coverage.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd # main
 
   current-spec-compliance:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/requirements-tracing.yaml@c9fb74b20429e69c15021c64dcf343447a2f46a2 # main
+    uses: eclipse-uprotocol/ci-cd/.github/workflows/requirements-tracing.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd # main
     with:
       env-file-suffix: "oft-current"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,19 +29,19 @@ jobs:
     uses: ./.github/workflows/check.yaml
 
   check-msrv:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-verify-msrv.yaml@c9fb74b20429e69c15021c64dcf343447a2f46a2 # main
+    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-verify-msrv.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd # main
 
   coverage:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-coverage.yaml@c9fb74b20429e69c15021c64dcf343447a2f46a2 # main
+    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-coverage.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd # main
 
   current-spec-compliance:
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/requirements-tracing.yaml@c9fb74b20429e69c15021c64dcf343447a2f46a2 # main
+    uses: eclipse-uprotocol/ci-cd/.github/workflows/requirements-tracing.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd # main
     with:
       env-file-suffix: "oft-current"
 
   licenses:
     # This works off the license declarations in dependent packages/crates, so if these declarations are wrong, this report will contain erroneous information
-    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-license-report.yaml@c9fb74b20429e69c15021c64dcf343447a2f46a2 # main
+    uses: eclipse-uprotocol/ci-cd/.github/workflows/rust-license-report.yaml@fcaf488b5d152c290a3a8dca2463a5c1dec65acd # main
     with:
       templates: "about.hbs"
       config: "about.toml"


### PR DESCRIPTION
In particular, we now support reading OFT spec items from proto files.