### PR TITLE
Use Trusted Publishing for Release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************/
 
-# Create artifacts for project releases
+# Create release artifacts and publish to crates.io.
 
 name: Release
 
@@ -86,10 +86,8 @@ jobs:
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         id: upload_license_report
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/license/*
           file_glob: true
-          tag: ${{ github.ref }}
 
       # Requirements Tracing report - we later need the download_url output of the upload step
       - name: Download requirements tracing report
@@ -101,10 +99,8 @@ jobs:
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         id: upload_requirements_tracing_report
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/tracing/*
           file_glob: true
-          tag: ${{ github.ref }}
 
       # Test results - we later need the download_url output of the upload step
       - name: Download test report
@@ -116,10 +112,8 @@ jobs:
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         id: upload_test_report
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/tests/*
           file_glob: true
-          tag: ${{ github.ref }}
 
       # Test coverage - we later need the download_url output of the upload step
       - name: Download test coverage
@@ -131,19 +125,15 @@ jobs:
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         id: upload_test_coverage
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/codecov/*
           file_glob: true
-          tag: ${{ github.ref }}
 
       # README - we later need the download_url output of the upload step
       - name: Upload README to release
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         id: upload_readme
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: README.md
-          tag: ${{ github.ref }}
 
       - name: Gather uProtocol Specification documents
         shell: bash
@@ -153,9 +143,7 @@ jobs:
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         id: upload_up_spec
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: up-spec.tar.gz
-          tag: ${{ github.ref }}
 
       - name: Gets latest created release info
         id: latest_release_info
@@ -177,25 +165,32 @@ jobs:
         uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         id: upload_quality_manifest
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ steps.quevee_manifest.outputs.manifest_file }}
-          tag: ${{ github.ref }}
 
+  # Publish crate to crates.io - this will only do a dry-run to verify that the publish would succeed, if the
+  # CRATES_IO_DRY_RUN environment variable is set to a value that GitHub Actions evaluates to 'true'
+  # (see https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#literals).
+  # Otherwise the job will try to actually publish the crate "for real".
   cargo-publish:
-    name: publish to crates.io
+    name: Publish to crates.io
     # This will publish to crates.io if secrets.CRATES_TOKEN is set in the workspace, otherwise do a dry-run
     runs-on: ubuntu-latest
     needs:
       - tag_release_artifacts
-    env: 
-      CRATES_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+    permissions:
+      id-token: write # needed for cargo publish with OIDC token
+    env:
+      DRY_RUN: ${{ vars.CRATES_IO_DRY_RUN || 'false' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: "recursive"
           persist-credentials: false
-
-      - if: env.CRATES_TOKEN == ''
+      - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+        id: auth
+      - if: env.DRY_RUN
         run: cargo publish --all-features --dry-run
-      - if: env.CRATES_TOKEN != ''
-        run: cargo publish --all-features --token ${CRATES_TOKEN}
+      - if: ! env.DRY_RUN
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish --all-features --token ${CARGO_REGISTRY_TOKEN}


### PR DESCRIPTION
Modified the release.yaml workflow to no longer use a long lived secret for authentication to crates.io, but instead use Trusted Publishing based on short lived tokens as described in https://crates.io/docs/trusted-publishing