### PR TITLE
Use Typestate pattern for UMessageBuilder

### DIFF
--- a/examples/simple_publish.rs
+++ b/examples/simple_publish.rs
@@ -17,7 +17,7 @@ use protobuf::well_known_types::wrappers::StringValue;
 use up_rust::{
     communication::{CallOptions, Publisher, SimplePublisher, UPayload},
     local_transport::LocalTransport,
-    LocalUriProvider, StaticUriProvider, UListener, UMessage, UTransport,
+    LocalUriProvider, StaticUriProvider, UListener, UMessage, UMessageBuilder, UTransport,
 };
 
 struct ConsolePrinter {}
@@ -25,8 +25,21 @@ struct ConsolePrinter {}
 #[async_trait::async_trait]
 impl UListener for ConsolePrinter {
     async fn on_receive(&self, msg: UMessage) {
-        if let Ok(payload) = msg.extract_protobuf::<StringValue>() {
-            println!("received event: {}", payload.value);
+        match msg.payload_format() {
+            Some(up_rust::UPayloadFormat::Text) => {
+                if let Some(payload) = msg.payload() {
+                    let msg = String::from_utf8(payload.to_vec()).unwrap();
+                    println!("received event: {}", msg);
+                }
+            }
+            Some(up_rust::UPayloadFormat::ProtobufWrappedInAny) => {
+                if let Ok(payload) = msg.extract_protobuf::<StringValue>() {
+                    println!("received event: {}", payload.value);
+                }
+            }
+            _ => {
+                println!("received event with unsupported payload format");
+            }
         }
     }
 }
@@ -42,19 +55,24 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let transport = Arc::new(LocalTransport::default());
     let publisher = SimplePublisher::new(transport.clone(), uri_provider.clone());
     let listener = Arc::new(ConsolePrinter {});
+    let topic = uri_provider.get_resource_uri(ORIGIN_RESOURCE_ID);
 
     transport
-        .register_listener(
-            &uri_provider.get_resource_uri(ORIGIN_RESOURCE_ID),
-            None,
-            listener.clone(),
-        )
+        .register_listener(&topic, None, listener.clone())
         .await?;
 
+    // sending message via L1 Transport API, which is used by the Publisher internally
+    let msg = UMessageBuilder::publish(topic.clone())
+        .build_with_payload("Hello plain text", up_rust::UPayloadFormat::Text)?;
+    transport.send(msg).await?;
+
+    // now sending a message via the Publisher API, which is the recommended way to send messages
+    // as it handles all the necessary details for you, such as setting the correct URIs and CallOptions
     let value = StringValue {
-        value: "Hello".to_string(),
+        value: "Hello protobuf".to_string(),
         ..Default::default()
     };
+
     let payload = UPayload::try_from_protobuf(value)?;
     publisher
         .publish(
@@ -64,12 +82,14 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
+    // At this point we can be sure that all events have been processed already.
+    // This is because the LocalTransport dispatches all messages to listeners on the same
+    // thread that has been used to send the messages.
+    // When using an asynchronous transport, such as MQTT5 or Eclipse Zenoh, we would need to
+    // notify the sender from within the listener, e.g. by means of a Channel, before stopping
+    // the listener.
     transport
-        .unregister_listener(
-            &uri_provider.get_resource_uri(ORIGIN_RESOURCE_ID),
-            None,
-            listener,
-        )
+        .unregister_listener(&topic, None, listener)
         .await?;
 
     Ok(())

--- a/examples/simple_publish.rs
+++ b/examples/simple_publish.rs
@@ -25,16 +25,17 @@ struct ConsolePrinter {}
 #[async_trait::async_trait]
 impl UListener for ConsolePrinter {
     async fn on_receive(&self, msg: UMessage) {
+        let priority = msg.priority().map_or("None", |p| p.to_priority_code());
         match msg.payload_format() {
             Some(up_rust::UPayloadFormat::Text) => {
                 if let Some(payload) = msg.payload() {
                     let msg = String::from_utf8(payload.to_vec()).unwrap();
-                    println!("received event: {}", msg);
+                    println!("received event [priority: {}]: {}", priority, msg);
                 }
             }
             Some(up_rust::UPayloadFormat::ProtobufWrappedInAny) => {
                 if let Ok(payload) = msg.extract_protobuf::<StringValue>() {
-                    println!("received event: {}", payload.value);
+                    println!("received event [priority: {}]: {}", priority, payload.value);
                 }
             }
             _ => {
@@ -63,6 +64,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // sending message via L1 Transport API, which is used by the Publisher internally
     let msg = UMessageBuilder::publish(topic.clone())
+        .with_priority(up_rust::UPriority::CS2)
         .build_with_payload("Hello plain text", up_rust::UPayloadFormat::Text)?;
     transport.send(msg).await?;
 
@@ -77,7 +79,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     publisher
         .publish(
             ORIGIN_RESOURCE_ID,
-            CallOptions::for_publish(None, None, None),
+            CallOptions::for_publish(None, None, Some(up_rust::UPriority::CS3)),
             Some(payload),
         )
         .await?;

--- a/src/communication.rs
+++ b/src/communication.rs
@@ -67,9 +67,9 @@ pub use in_memory_rpc_server::InMemoryRpcServer;
 /// * message ID
 /// * priority
 #[cfg(any(feature = "up-l2-notifier", feature = "up-l2-publisher"))]
-pub(crate) fn apply_common_options(
+pub(crate) fn apply_common_options<S: crate::umessage::BuilderState>(
     call_options: CallOptions,
-    message_builder: &mut crate::UMessageBuilder,
+    message_builder: &mut crate::UMessageBuilder<S>,
 ) {
     message_builder.with_ttl(call_options.ttl);
     if let Some(v) = call_options.message_id {
@@ -87,8 +87,8 @@ pub(crate) fn apply_common_options(
     feature = "up-l2-rpc-client",
     feature = "up-l2-rpc-server"
 ))]
-pub(crate) fn build_message(
-    message_builder: &mut crate::UMessageBuilder,
+pub(crate) fn build_message<S: crate::umessage::BuilderState>(
+    message_builder: &mut crate::UMessageBuilder<S>,
     payload: Option<UPayload>,
 ) -> Result<crate::UMessage, crate::UMessageError> {
     if let Some(pl) = payload {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,10 @@ pub use uattributes::{
 };
 
 mod umessage;
-pub use umessage::{UMessage, UMessageBuilder, UMessageError};
+pub use umessage::{
+    BuilderState, NotificationBuilderState, PublishBuilderState, RequestBuilderState,
+    ResponseBuilderState, UMessage, UMessageBuilder, UMessageError,
+};
 
 mod uri;
 pub use uri::{UUri, UUriError};

--- a/src/uattributes.rs
+++ b/src/uattributes.rs
@@ -81,6 +81,17 @@ impl From<UPayloadError> for UAttributesError {
     }
 }
 
+/// The attributes of a uProtocol message.
+///
+/// These attributes provide metadata about the message, such as its type, identifier, source and destination addresses, priority, time-to-live, etc. They are used by the uProtocol library to manage the message and its
+/// lifecycle, and can also be accessed by applications to make informed decisions about how to handle the message.
+///
+/// Attributes are immutable and are set when the message is created using [crate::UMessageBuilder]. They cannot be
+/// changed afterwards.
+///
+/// The attributes of a message can be accessed via the [`crate::UMessage::attributes`] function. For convenience,
+/// [`crate::UMessage`] also has functions for directly accessing the attribute values, mimicking the functions
+/// provided by this struct.
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
 pub struct UAttributes {
@@ -100,82 +111,24 @@ pub struct UAttributes {
 
 impl UAttributes {
     /// Gets the type of message these are the attributes of.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use up_rust::{UMessageBuilder, UMessageType, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let topic = UUri::try_from("//my-vehicle/D45/23/A001")?;
-    /// let msg = UMessageBuilder::publish(topic).build()?;
-    /// let attribs = msg.attributes();
-    /// assert_eq!(attribs.type_(), UMessageType::Publish);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn type_(&self) -> UMessageType {
         self.type_
     }
 
     /// Gets the identifier of the message these attributes belong to.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use up_rust::{UMessageBuilder, UMessageType, UUri, UUID};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let topic = UUri::try_from("//my-vehicle/D45/23/A001")?;
-    /// let msg_id = UUID::build();
-    /// let msg = UMessageBuilder::publish(topic).with_message_id(msg_id.clone()).build()?;
-    /// let attribs = msg.attributes();
-    /// assert_eq!(attribs.id(), &msg_id);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn id(&self) -> &UUID {
         &self.id
     }
 
     /// Gets the source address of the message these attributes belong to.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use up_rust::{UMessageBuilder, UMessageType, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let topic = UUri::try_from("//my-vehicle/D45/23/A001")?;
-    /// let msg = UMessageBuilder::publish(topic.clone()).build()?;
-    /// let attribs = msg.attributes();
-    /// assert_eq!(attribs.source(), &topic);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn source(&self) -> &UUri {
         &self.source
     }
 
     /// Gets the sink address of the message these attributes belong to.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use up_rust::{UMessageBuilder, UMessageType, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let origin = UUri::try_from("//my-vehicle/D45/23/A001")?;
-    /// let dest = UUri::try_from("//other-vehicle/D10/3/0")?;
-    /// let msg = UMessageBuilder::notification(origin, dest.clone()).build()?;
-    /// let attribs = msg.attributes();
-    /// assert_eq!(attribs.sink(), Some(&dest));
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn sink(&self) -> Option<&UUri> {
         self.sink.as_ref()
@@ -186,41 +139,12 @@ impl UAttributes {
     /// # Panics
     ///
     /// if the property has no value.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use up_rust::{UMessageBuilder, UMessageType, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let origin = UUri::try_from("//my-vehicle/D45/23/A001")?;
-    /// let dest = UUri::try_from("//other-vehicle/D10/3/0")?;
-    /// let msg = UMessageBuilder::notification(origin, dest.clone()).build()?;
-    /// let attribs = msg.attributes();
-    /// assert_eq!(attribs.sink_unchecked(), &dest);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn sink_unchecked(&self) -> &UUri {
         self.sink().expect("message has no sink")
     }
 
     /// Gets the priority of the message these attributes belong to.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use up_rust::{UMessageBuilder, UMessageType, UPriority, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let topic = UUri::try_from("//my-vehicle/D45/23/A001")?;
-    /// let msg = UMessageBuilder::publish(topic).with_priority(UPriority::CS3).build()?;
-    /// let attribs = msg.attributes();
-    /// assert_eq!(attribs.priority(), Some(UPriority::CS3));
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn priority(&self) -> Option<UPriority> {
         self.priority
@@ -231,43 +155,12 @@ impl UAttributes {
     /// # Panics
     ///
     /// if the property has no value.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use up_rust::{UMessageBuilder, UMessageType, UPriority, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let topic = UUri::try_from("//my-vehicle/D45/23/A001")?;
-    /// let msg = UMessageBuilder::publish(topic).with_priority(UPriority::CS3).build()?;
-    /// let attribs = msg.attributes();
-    /// assert_eq!(attribs.priority_unchecked(), UPriority::CS3);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn priority_unchecked(&self) -> UPriority {
         self.priority().expect("message has no priority")
     }
 
     /// Gets the commstatus of the message these attributes belong to.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use up_rust::{UCode, UMessageBuilder, UMessageType, UUID, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
-    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
-    /// let msg = UMessageBuilder::response(reply_to, UUID::build(), invoked_method)
-    ///   .with_comm_status(UCode::Ok)
-    ///   .build()?;
-    /// let attribs = msg.attributes();
-    /// assert_eq!(attribs.commstatus(), Some(UCode::Ok));
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn commstatus(&self) -> Option<UCode> {
         self.commstatus
@@ -278,23 +171,6 @@ impl UAttributes {
     /// # Panics
     ///
     /// if the property has no value.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use up_rust::{UCode, UMessageBuilder, UMessageType, UUID, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
-    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
-    /// let msg = UMessageBuilder::response(reply_to, UUID::build(), invoked_method)
-    ///   .with_comm_status(UCode::Internal)
-    ///   .build()?;
-    /// let attribs = msg.attributes();
-    /// assert_eq!(attribs.commstatus_unchecked(), UCode::Internal);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn commstatus_unchecked(&self) -> UCode {
         self.commstatus().expect("message has no commstatus")
@@ -305,22 +181,6 @@ impl UAttributes {
     /// # Returns
     ///
     /// the time-to-live in milliseconds.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use up_rust::{UMessageBuilder, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
-    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
-    /// let msg = UMessageBuilder::request(invoked_method, reply_to, 5000)
-    ///   .build()?;
-    /// let attribs = msg.attributes();
-    /// assert_eq!(attribs.ttl(), Some(5000));
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn ttl(&self) -> Option<u32> {
         self.ttl
@@ -335,116 +195,30 @@ impl UAttributes {
     /// # Panics
     ///
     /// if the property has no value.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use up_rust::{UMessageBuilder, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
-    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
-    /// let msg = UMessageBuilder::request(invoked_method, reply_to, 5000)
-    ///   .build()?;
-    /// let attribs = msg.attributes();
-    /// assert_eq!(attribs.ttl_unchecked(), 5000);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn ttl_unchecked(&self) -> u32 {
         self.ttl().expect("message has no time-to-live")
     }
 
     /// Gets the permission level of the message these attributes belong to.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use up_rust::{UMessageBuilder, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
-    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
-    /// let msg = UMessageBuilder::request(invoked_method, reply_to, 5000)
-    ///   .with_permission_level(3)
-    ///   .build()?;
-    /// let attribs = msg.attributes();
-    /// assert_eq!(attribs.permission_level(), Some(3));
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn permission_level(&self) -> Option<u32> {
         self.permission_level
     }
 
     /// Gets the token of the message these attributes belong to.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use up_rust::{UMessageBuilder, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let token = "my_token";
-    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
-    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
-    /// let msg = UMessageBuilder::request(invoked_method, reply_to, 5000)
-    ///   .with_token(token)
-    ///   .build()?;
-    /// let attribs = msg.attributes();
-    /// assert_eq!(attribs.token(), Some(token));
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn token(&self) -> Option<&str> {
         self.token.as_deref()
     }
 
     /// Gets the traceparent of the message these attributes belong to.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use up_rust::{UMessageBuilder, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let traceparent = "my_traceparent";
-    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
-    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
-    /// let msg = UMessageBuilder::request(invoked_method, reply_to, 5000)
-    ///   .with_traceparent(traceparent)
-    ///   .build()?;
-    /// let attribs = msg.attributes();
-    /// assert_eq!(attribs.traceparent(), Some(traceparent));
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn traceparent(&self) -> Option<&str> {
         self.traceparent.as_deref()
     }
 
     /// Gets the request identifier of the message these attributes belong to.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use up_rust::{UCode, UMessageBuilder, UUID, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let request_id = UUID::build();
-    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
-    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
-    /// let msg = UMessageBuilder::response(reply_to, request_id.clone(), invoked_method)
-    ///   .build()?;
-    /// let attribs = msg.attributes();
-    /// assert_eq!(attribs.request_id(), Some(&request_id));
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn request_id(&self) -> Option<&UUID> {
         self.reqid.as_ref()
@@ -455,44 +229,12 @@ impl UAttributes {
     /// # Panics
     ///
     /// if the property has no value.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use up_rust::{UCode, UMessageBuilder, UUID, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let request_id = UUID::build();
-    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
-    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
-    /// let msg = UMessageBuilder::response(reply_to, request_id.clone(), invoked_method)
-    ///   .build()?;
-    /// let attribs = msg.attributes();
-    /// assert_eq!(attribs.request_id_unchecked(), &request_id);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn request_id_unchecked(&self) -> &UUID {
         self.request_id().expect("message has no request ID")
     }
 
     /// Gets the payload format of the message these attributes belong to.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use up_rust::{UMessageBuilder, UPayloadFormat, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let topic = UUri::try_from("//my-vehicle/D45/23/A001")?;
-    /// let msg = UMessageBuilder::publish(topic)
-    ///   .build_with_payload("hello".as_bytes(), UPayloadFormat::Text)?;
-    /// let attribs = msg.attributes();
-    /// assert_eq!(attribs.payload_format(), Some(UPayloadFormat::Text));
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn payload_format(&self) -> Option<UPayloadFormat> {
         self.payload_format
@@ -503,21 +245,6 @@ impl UAttributes {
     /// # Panics
     ///
     /// if the property has no value.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use up_rust::{UMessageBuilder, UPayloadFormat, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let topic = UUri::try_from("//my-vehicle/D45/23/A001")?;
-    /// let msg = UMessageBuilder::publish(topic)
-    ///   .build_with_payload("hello".as_bytes(), UPayloadFormat::Text)?;
-    /// let attribs = msg.attributes();
-    /// assert_eq!(attribs.payload_format_unchecked(), UPayloadFormat::Text);
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn payload_format_unchecked(&self) -> UPayloadFormat {
         self.payload_format()
@@ -533,85 +260,24 @@ impl UAttributes {
     }
 
     /// Checks if these are the attributes for a Publish message.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use up_rust::{UMessageBuilder, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let topic = UUri::try_from("//my-vehicle/D45/23/A001")?;
-    /// let msg = UMessageBuilder::publish(topic).build()?;
-    /// let attribs = msg.attributes();
-    /// assert!(attribs.is_publish());
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn is_publish(&self) -> bool {
         self.type_ == UMessageType::Publish
     }
 
     /// Checks if these are the attributes for an RPC Request message.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use up_rust::{UMessageBuilder, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
-    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
-    /// let msg = UMessageBuilder::request(invoked_method, reply_to, 5000)
-    ///   .build()?;
-    /// let attribs = msg.attributes();
-    /// assert!(attribs.is_request());
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn is_request(&self) -> bool {
         self.type_ == UMessageType::Request
     }
 
     /// Checks if these are the attributes for an RPC Response message.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use up_rust::{UCode, UMessageBuilder, UUID, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
-    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
-    /// let msg = UMessageBuilder::response(reply_to, UUID::build(), invoked_method)
-    ///   .build()?;
-    /// let attribs = msg.attributes();
-    /// assert!(attribs.is_response());
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn is_response(&self) -> bool {
         self.type_ == UMessageType::Response
     }
 
     /// Checks if these are the attributes for a Notification message.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use up_rust::{UMessageBuilder, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let origin = UUri::try_from("//my-vehicle/D45/23/A001")?;
-    /// let dest = UUri::try_from("//other-vehicle/D10/3/0")?;
-    /// let msg = UMessageBuilder::notification(origin, dest).build()?;
-    /// let attribs = msg.attributes();
-    /// assert!(attribs.is_notification());
-    /// # Ok(())
-    /// # }
-    /// ```
     #[must_use]
     pub fn is_notification(&self) -> bool {
         self.type_ == UMessageType::Notification
@@ -643,7 +309,9 @@ impl UAttributes {
     /// Checks if the message that is described by these attributes should be considered expired.
     ///
     /// # Arguments
-    /// * `reference_time` - The reference time as a `Duration` since UNIX epoch. The check will be performed in relation to this point in time.
+    ///
+    /// * `reference_time` - The reference time as milliseconds since UNIX epoch. The check will
+    ///   be performed in relation to this point in time.
     ///
     /// # Errors
     ///

--- a/src/umessage.rs
+++ b/src/umessage.rs
@@ -13,15 +13,14 @@
 
 use bytes::Bytes;
 
+#[cfg(all(feature = "up-l2-api", feature = "protobuf-support"))]
+pub(crate) use protobuf_support::deserialize_protobuf_bytes;
 pub use umessagebuilder::*;
 
 use crate::{
     SerializationError, UAttributes, UAttributesError, UCode, UMessageType, UPayloadFormat,
     UPriority, UUri, UUID,
 };
-
-#[cfg(feature = "protobuf-support")]
-use crate::ProtobufMappable;
 
 mod umessagebuilder;
 
@@ -89,6 +88,9 @@ pub struct UMessage {
 }
 
 impl UMessage {
+    // This convenience constructor is used internally only, e.g. by the UMessageBuilder for creating
+    // the final message after validation.
+    // Client code can create UMessages using the UMessageBuilder only.
     pub(crate) fn new(
         attributes: UAttributes,
         payload: Option<Bytes>,
@@ -100,6 +102,21 @@ impl UMessage {
     }
 
     /// Get this message's attributes.
+    ///
+    /// This function simply delegates to [`UAttributes::type_`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use up_rust::{UMessageBuilder, UMessageType, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let topic = UUri::try_from("//my-vehicle/D45/23/A001")?;
+    /// let msg = UMessageBuilder::publish(topic).build()?;
+    /// assert_eq!(msg.type_(), UMessageType::Publish);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn attributes(&self) -> &UAttributes {
         &self.attributes
@@ -112,18 +129,65 @@ impl UMessage {
     }
 
     /// Gets this message's identifier.
+    ///
+    /// This function simply delegates to [`UAttributes::id`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use up_rust::{UMessageBuilder, UMessageType, UUri, UUID};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let topic = UUri::try_from("//my-vehicle/D45/23/A001")?;
+    /// let msg_id = UUID::build();
+    /// let msg = UMessageBuilder::publish(topic).with_message_id(msg_id.clone()).build()?;
+    /// assert_eq!(msg.id(), &msg_id);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn id(&self) -> &UUID {
         self.attributes().id()
     }
 
     /// Gets this message's source address.
+    ///
+    /// This function simply delegates to [`UAttributes::source`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use up_rust::{UMessageBuilder, UMessageType, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let topic = UUri::try_from("//my-vehicle/D45/23/A001")?;
+    /// let msg = UMessageBuilder::publish(topic.clone()).build()?;
+    /// assert_eq!(msg.source(), &topic);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn source(&self) -> &UUri {
         self.attributes().source()
     }
 
     /// Gets this message's sink address.
+    ///
+    /// This function simply delegates to [`UAttributes::sink`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use up_rust::{UMessageBuilder, UMessageType, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let origin = UUri::try_from("//my-vehicle/D45/23/A001")?;
+    /// let dest = UUri::try_from("//other-vehicle/D10/3/0")?;
+    /// let msg = UMessageBuilder::notification(origin, dest.clone()).build()?;
+    /// assert!(msg.sink().is_some_and(|sink| sink == &dest));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn sink(&self) -> Option<&UUri> {
         self.attributes().sink()
@@ -131,15 +195,46 @@ impl UMessage {
 
     /// Gets this message's sink address.
     ///
+    /// This function simply delegates to [`UAttributes::sink_unchecked`].
+    ///
     /// # Panics
     ///
     /// if the property has no value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use up_rust::{UMessageBuilder, UMessageType, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let origin = UUri::try_from("//my-vehicle/D45/23/A001")?;
+    /// let dest = UUri::try_from("//other-vehicle/D10/3/0")?;
+    /// let msg = UMessageBuilder::notification(origin, dest.clone()).build()?;
+    /// assert_eq!(msg.sink_unchecked(), &dest);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn sink_unchecked(&self) -> &UUri {
         self.attributes().sink_unchecked()
     }
 
     /// Gets this message's priority.
+    ///
+    /// This function simply delegates to [`UAttributes::priority`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use up_rust::{UMessageBuilder, UMessageType, UPriority, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let topic = UUri::try_from("//my-vehicle/D45/23/A001")?;
+    /// let msg = UMessageBuilder::publish(topic).with_priority(UPriority::CS3).build()?;
+    /// assert!(msg.priority().is_some_and(|prio| prio == UPriority::CS3));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn priority(&self) -> Option<UPriority> {
         self.attributes().priority()
@@ -147,15 +242,48 @@ impl UMessage {
 
     /// Gets this message's priority.
     ///
+    /// This function simply delegates to [`UAttributes::priority_unchecked`].
+    ///
     /// # Panics
     ///
     /// if the property has no value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use up_rust::{UMessageBuilder, UMessageType, UPriority, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let topic = UUri::try_from("//my-vehicle/D45/23/A001")?;
+    /// let msg = UMessageBuilder::publish(topic).with_priority(UPriority::CS3).build()?;
+    /// assert_eq!(msg.priority_unchecked(), UPriority::CS3);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn priority_unchecked(&self) -> UPriority {
         self.attributes().priority_unchecked()
     }
 
     /// Gets this message's commstatus.
+    ///
+    /// This function simply delegates to [`UAttributes::commstatus`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use up_rust::{UCode, UMessageBuilder, UMessageType, UUID, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
+    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
+    /// let msg = UMessageBuilder::response(reply_to, UUID::build(), invoked_method)
+    ///   .with_comm_status(UCode::Ok)
+    ///   .build()?;
+    /// assert!(msg.commstatus().is_some_and(|status| status == UCode::Ok));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn commstatus(&self) -> Option<UCode> {
         self.attributes().commstatus()
@@ -163,9 +291,27 @@ impl UMessage {
 
     /// Gets this message's commstatus.
     ///
+    /// This function simply delegates to [`UAttributes::commstatus_unchecked`].
+    ///
     /// # Panics
     ///
     /// if the property has no value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use up_rust::{UCode, UMessageBuilder, UMessageType, UUID, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
+    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
+    /// let msg = UMessageBuilder::response(reply_to, UUID::build(), invoked_method)
+    ///   .with_comm_status(UCode::Internal)
+    ///   .build()?;
+    /// assert_eq!(msg.commstatus_unchecked(), UCode::Internal);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn commstatus_unchecked(&self) -> UCode {
         self.attributes().commstatus_unchecked()
@@ -173,9 +319,26 @@ impl UMessage {
 
     /// Gets this message's time-to-live.
     ///
+    /// This function simply delegates to [`UAttributes::ttl`].
+    ///
     /// # Returns
     ///
     /// the time-to-live in milliseconds.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use up_rust::{UMessageBuilder, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
+    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
+    /// let msg = UMessageBuilder::request(invoked_method, reply_to, 5000)
+    ///   .build()?;
+    /// assert!(msg.ttl().is_some_and(|ttl| ttl == 5000));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn ttl(&self) -> Option<u32> {
         self.attributes().ttl()
@@ -183,6 +346,8 @@ impl UMessage {
 
     /// Gets this message's time-to-live.
     ///
+    /// This function simply delegates to [`UAttributes::ttl_unchecked`].
+    ///
     /// # Returns
     ///
     /// the time-to-live in milliseconds.
@@ -190,30 +355,119 @@ impl UMessage {
     /// # Panics
     ///
     /// if the property has no value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use up_rust::{UMessageBuilder, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
+    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
+    /// let msg = UMessageBuilder::request(invoked_method, reply_to, 5000)
+    ///   .build()?;
+    /// assert!(msg.ttl_unchecked() == 5000);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn ttl_unchecked(&self) -> u32 {
         self.attributes().ttl_unchecked()
     }
 
     /// Gets this message's permission level.
+    ///
+    /// This function simply delegates to [`UAttributes::permission_level`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use up_rust::{UMessageBuilder, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
+    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
+    /// let msg = UMessageBuilder::request(invoked_method, reply_to, 5000)
+    ///   .with_permission_level(3)
+    ///   .build()?;
+    /// assert!(msg.permission_level().is_some_and(|pl| pl == 3));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn permission_level(&self) -> Option<u32> {
         self.attributes().permission_level()
     }
 
     /// Gets this message's token.
+    ///
+    /// This function simply delegates to [`UAttributes::token`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use up_rust::{UMessageBuilder, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let token = "my_token";
+    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
+    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
+    /// let msg = UMessageBuilder::request(invoked_method, reply_to, 5000)
+    ///   .with_token(token)
+    ///   .build()?;
+    /// assert!(msg.token().is_some_and(|t| t == token));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn token(&self) -> Option<&str> {
         self.attributes().token()
     }
 
     /// Gets this message's traceparent.
+    ///
+    /// This function simply delegates to [`UAttributes::traceparent`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use up_rust::{UMessageBuilder, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let traceparent = "my_traceparent";
+    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
+    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
+    /// let msg = UMessageBuilder::request(invoked_method, reply_to, 5000)
+    ///   .with_traceparent(traceparent)
+    ///   .build()?;
+    /// assert!(msg.traceparent().is_some_and(|tp| tp == traceparent));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn traceparent(&self) -> Option<&str> {
         self.attributes().traceparent()
     }
 
     /// Gets this message's request identifier.
+    ///
+    /// This function simply delegates to [`UAttributes::request_id`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use up_rust::{UCode, UMessageBuilder, UUID, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let request_id = UUID::build();
+    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
+    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
+    /// let msg = UMessageBuilder::response(reply_to, request_id.clone(), invoked_method)
+    ///   .build()?;
+    /// assert!(msg.request_id().is_some_and(|id| id == &request_id));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn request_id(&self) -> Option<&UUID> {
         self.attributes().request_id()
@@ -221,15 +475,49 @@ impl UMessage {
 
     /// Gets this message's request identifier.
     ///
+    /// This function simply delegates to [`UAttributes::request_id_unchecked`].
+    ///
     /// # Panics
     ///
     /// if the property has no value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use up_rust::{UCode, UMessageBuilder, UUID, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let request_id = UUID::build();
+    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
+    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
+    /// let msg = UMessageBuilder::response(reply_to, request_id.clone(), invoked_method)
+    ///   .build()?;
+    /// assert_eq!(msg.request_id_unchecked(), &request_id);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn request_id_unchecked(&self) -> &UUID {
         self.attributes().request_id_unchecked()
     }
 
     /// Gets this message's payload format.
+    ///
+    /// This function simply delegates to [`UAttributes::payload_format`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use up_rust::{UMessageBuilder, UPayloadFormat, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let topic = UUri::try_from("//my-vehicle/D45/23/A001")?;
+    /// let msg = UMessageBuilder::publish(topic)
+    ///   .build_with_payload("hello".as_bytes(), UPayloadFormat::Text)?;
+    /// assert!(msg.payload_format().is_some_and(|format| format == UPayloadFormat::Text));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn payload_format(&self) -> Option<UPayloadFormat> {
         self.attributes().payload_format()
@@ -237,9 +525,25 @@ impl UMessage {
 
     /// Gets this message's payload format.
     ///
+    /// This function simply delegates to [`UAttributes::payload_format_unchecked`].
+    ///
     /// # Panics
     ///
     /// if the property has no value.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use up_rust::{UMessageBuilder, UPayloadFormat, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let topic = UUri::try_from("//my-vehicle/D45/23/A001")?;
+    /// let msg = UMessageBuilder::publish(topic)
+    ///   .build_with_payload("hello".as_bytes(), UPayloadFormat::Text)?;
+    /// assert_eq!(msg.payload_format_unchecked(), UPayloadFormat::Text);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn payload_format_unchecked(&self) -> UPayloadFormat {
         self.attributes().payload_format_unchecked()
@@ -252,15 +556,19 @@ impl UMessage {
 
     /// Checks if this is a Publish message.
     ///
+    /// This function simply delegates to [`UAttributes::is_publish`].
+    ///
     /// # Examples
     ///
     /// ```rust
     /// use up_rust::{UMessageBuilder, UUri};
     ///
-    /// let msg = UMessageBuilder::publish(
-    ///   UUri::try_from_parts("origin", 0xabcd, 0x01, 0x9000).unwrap(),
-    /// ).build().unwrap();
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let topic = UUri::try_from("//my-vehicle/D45/23/A001")?;
+    /// let msg = UMessageBuilder::publish(topic).build()?;
     /// assert!(msg.is_publish());
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn is_publish(&self) -> bool {
@@ -269,17 +577,21 @@ impl UMessage {
 
     /// Checks if this is an RPC Request message.
     ///
+    /// This function simply delegates to [`UAttributes::is_request`].
+    ///
     /// # Examples
     ///
     /// ```rust
-    /// use up_rust::{UMessageBuilder, UUID, UUri};
+    /// use up_rust::{UMessageBuilder, UUri};
     ///
-    /// let msg = UMessageBuilder::request(
-    ///   UUri::try_from_parts("server", 0x1234, 0x01, 0x1000).unwrap(),
-    ///   UUri::try_from_parts("client", 0xabcd, 0x01, 0x0000).unwrap(),
-    ///   5000,
-    /// ).build().unwrap();
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
+    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
+    /// let msg = UMessageBuilder::request(invoked_method, reply_to, 5000)
+    ///   .build()?;
     /// assert!(msg.is_request());
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn is_request(&self) -> bool {
@@ -288,17 +600,21 @@ impl UMessage {
 
     /// Checks if this is an RPC Response message.
     ///
+    /// This function simply delegates to [`UAttributes::is_response`].
+    ///
     /// # Examples
     ///
     /// ```rust
-    /// use up_rust::{UMessageBuilder, UUID, UUri};
+    /// use up_rust::{UCode, UMessageBuilder, UUID, UUri};
     ///
-    /// let msg = UMessageBuilder::response(
-    ///   UUri::try_from_parts("client", 0xabcd, 0x01, 0x0000).unwrap(),
-    ///   UUID::build(),
-    ///   UUri::try_from_parts("server", 0x1234, 0x01, 0x1000).unwrap(),
-    /// ).build().unwrap();
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let invoked_method = UUri::try_from("//my-vehicle/D45/2/101")?;
+    /// let reply_to = UUri::try_from("//other-vehicle/D10/3/0")?;
+    /// let msg = UMessageBuilder::response(reply_to, UUID::build(), invoked_method)
+    ///   .build()?;
     /// assert!(msg.is_response());
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn is_response(&self) -> bool {
@@ -307,86 +623,244 @@ impl UMessage {
 
     /// Checks if this is a Notification message.
     ///
+    /// This function simply delegates to [`UAttributes::is_notification`].
+    ///
     /// # Examples
     ///
     /// ```rust
     /// use up_rust::{UMessageBuilder, UUri};
     ///
-    /// let msg = UMessageBuilder::notification(
-    ///   UUri::try_from_parts("origin", 0xabcd, 0x01, 0x9000).unwrap(),
-    ///   UUri::try_from_parts("dest", 0x1234, 0x01, 0x0000).unwrap(),
-    /// ).build().unwrap();
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let origin = UUri::try_from("//my-vehicle/D45/23/A001")?;
+    /// let dest = UUri::try_from("//other-vehicle/D10/3/0")?;
+    /// let msg = UMessageBuilder::notification(origin, dest).build()?;
     /// assert!(msg.is_notification());
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn is_notification(&self) -> bool {
         self.attributes().is_notification()
     }
 
-    /// Deserializes this message's protobuf payload into a type.
+    /// Checks if this message should be considered expired.
+    ///
+    /// This function simply delegates to [`UAttributes::check_expired`].
+    pub fn check_expired(&self) -> Result<(), UAttributesError> {
+        self.attributes().check_expired()
+    }
+
+    /// Checks if this message should be considered expired for a given reference time.
+    ///
+    /// This function simply delegates to [`UAttributes::check_expired_for_reference`].
+    ///
+    /// # Arguments
+    ///
+    /// * `reference_time` - The reference time as milliseconds since UNIX epoch. The check will
+    ///   be performed in relation to this point in time.
+    pub fn check_expired_for_reference(
+        &self,
+        reference_time: u128,
+    ) -> Result<(), UAttributesError> {
+        self.attributes()
+            .check_expired_for_reference(reference_time)
+    }
+}
+
+#[cfg(feature = "protobuf-support")]
+mod protobuf_support {
+    use super::*;
+    use crate::ProtobufMappable;
+
+    impl UMessage {
+        /// Deserializes this message's protobuf payload into a type.
+        ///
+        /// # Type Parameters
+        ///
+        /// * `T`: The target type of the data to be unpacked.
+        ///
+        /// # Errors
+        ///
+        /// Returns an error if the message payload format is neither [UPayloadFormat::Protobuf] nor
+        /// [UPayloadFormat::ProtobufWrappedInAny] or if the bytes in the
+        /// payload cannot be deserialized into the target type.
+        #[cfg(feature = "protobuf-support")]
+        pub fn extract_protobuf<T: ProtobufMappable>(&self) -> Result<T, UMessageError> {
+            if let Some(payload) = self.payload.as_ref() {
+                let payload_format = self.payload_format().unwrap_or(UPayloadFormat::Unspecified);
+                deserialize_protobuf_bytes(payload, &payload_format)
+            } else {
+                Err(UMessageError::PayloadError(
+                    "Message has no payload".to_string(),
+                ))
+            }
+        }
+    }
+
+    /// Deserializes a protobuf message from a byte array.
     ///
     /// # Type Parameters
     ///
     /// * `T`: The target type of the data to be unpacked.
     ///
+    /// # Arguments
+    ///
+    /// * `payload` - The payload data.
+    /// * `payload_format` - The format/encoding of the data. Must be one of
+    ///    - `UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF`
+    ///    - `UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY`
+    ///
     /// # Errors
     ///
-    /// Returns an error if the message payload format is neither [UPayloadFormat::Protobuf] nor
-    /// [UPayloadFormat::ProtobufWrappedInAny] or if the bytes in the
-    /// payload cannot be deserialized into the target type.
+    /// Returns an error if the payload format is unsupported or if the data can not be deserialized
+    /// into the target type based on the given format.
     #[cfg(feature = "protobuf-support")]
-    pub fn extract_protobuf<T: ProtobufMappable>(&self) -> Result<T, UMessageError> {
-        if let Some(payload) = self.payload.as_ref() {
-            let payload_format = self.payload_format().unwrap_or(UPayloadFormat::Unspecified);
-            deserialize_protobuf_bytes(payload, &payload_format)
-        } else {
-            Err(UMessageError::PayloadError(
-                "Message has no payload".to_string(),
-            ))
+    pub(crate) fn deserialize_protobuf_bytes<T: ProtobufMappable>(
+        payload: &[u8],
+        payload_format: &UPayloadFormat,
+    ) -> Result<T, UMessageError> {
+        match payload_format {
+            UPayloadFormat::Protobuf => {
+                T::parse_from_protobuf_bytes(payload).map_err(UMessageError::DataSerializationError)
+            }
+            UPayloadFormat::ProtobufWrappedInAny => T::parse_from_packed_protobuf_bytes(payload)
+                .map_err(UMessageError::DataSerializationError),
+            UPayloadFormat::Unspecified
+            | UPayloadFormat::Json
+            | UPayloadFormat::Raw
+            | UPayloadFormat::Shm
+            | UPayloadFormat::Someip
+            | UPayloadFormat::SomeipTlv
+            | UPayloadFormat::Text => {
+                let detail_msg = payload_format.to_media_type().map_or_else(
+                    || format!("Unknown payload format: {}", *payload_format as i32),
+                    |mt| format!("Invalid/unsupported payload format: {mt}"),
+                );
+                Err(UMessageError::from(detail_msg))
+            }
         }
     }
-}
 
-/// Deserializes a protobuf message from a byte array.
-///
-/// # Type Parameters
-///
-/// * `T`: The target type of the data to be unpacked.
-///
-/// # Arguments
-///
-/// * `payload` - The payload data.
-/// * `payload_format` - The format/encoding of the data. Must be one of
-///    - `UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF`
-///    - `UPayloadFormat::UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY`
-///
-/// # Errors
-///
-/// Returns an error if the payload format is unsupported or if the data can not be deserialized
-/// into the target type based on the given format.
-#[cfg(feature = "protobuf-support")]
-pub(crate) fn deserialize_protobuf_bytes<T: ProtobufMappable>(
-    payload: &[u8],
-    payload_format: &UPayloadFormat,
-) -> Result<T, UMessageError> {
-    match payload_format {
-        UPayloadFormat::Protobuf => {
-            T::parse_from_protobuf_bytes(payload).map_err(UMessageError::DataSerializationError)
+    #[cfg(test)]
+    mod protobuf_support_test {
+        use super::*;
+        use crate::UUri;
+
+        use protobuf::well_known_types::{
+            any::Any,
+            duration::Duration,
+            wrappers::{DoubleValue, StringValue},
+        };
+        use protobuf::Message;
+        use test_case::test_case;
+
+        #[test]
+        fn test_from_protobuf_error() {
+            let protobuf_error = protobuf::Error::from(std::io::Error::last_os_error());
+            let message_error = UMessageError::from(protobuf_error);
+            assert!(matches!(
+                message_error,
+                UMessageError::DataSerializationError(_)
+            ));
         }
-        UPayloadFormat::ProtobufWrappedInAny => T::parse_from_packed_protobuf_bytes(payload)
-            .map_err(UMessageError::DataSerializationError),
-        UPayloadFormat::Unspecified
-        | UPayloadFormat::Json
-        | UPayloadFormat::Raw
-        | UPayloadFormat::Shm
-        | UPayloadFormat::Someip
-        | UPayloadFormat::SomeipTlv
-        | UPayloadFormat::Text => {
-            let detail_msg = payload_format.to_media_type().map_or_else(
-                || format!("Unknown payload format: {}", *payload_format as i32),
-                |mt| format!("Invalid/unsupported payload format: {mt}"),
+
+        #[test]
+        fn test_deserialize_protobuf_bytes_succeeds() {
+            let mut data = StringValue::new();
+            data.value = "hello world".to_string();
+
+            let result = deserialize_protobuf_bytes::<StringValue>(
+                &data
+                    .write_to_bytes()
+                    .expect("Failed to write protobuf bytes"),
+                &UPayloadFormat::Protobuf,
             );
-            Err(UMessageError::from(detail_msg))
+            assert!(result.is_ok_and(|v| v.value == *"hello world"));
+
+            let any = Any::pack(&data).expect("Failed to pack Any");
+            let buf: Bytes = any
+                .write_to_bytes()
+                .expect("Failed to write protobuf bytes")
+                .into();
+
+            let result = deserialize_protobuf_bytes::<StringValue>(
+                &buf,
+                &UPayloadFormat::ProtobufWrappedInAny,
+            );
+            assert!(result.is_ok_and(|v| v.value == *"hello world"));
+        }
+
+        #[test]
+        fn test_deserialize_protobuf_bytes_fails_for_payload_type_mismatch() {
+            let mut data = StringValue::new();
+            data.value = "hello world".to_string();
+            let any = Any::pack(&data).unwrap();
+            let buf: Bytes = any.write_to_bytes().unwrap().into();
+            let result = deserialize_protobuf_bytes::<DoubleValue>(
+                &buf,
+                &UPayloadFormat::ProtobufWrappedInAny,
+            );
+            assert!(result.is_err_and(|e| matches!(e, UMessageError::DataSerializationError(_))));
+        }
+
+        #[test_case(UPayloadFormat::Json; "JSON format")]
+        #[test_case(UPayloadFormat::Raw; "RAW format")]
+        #[test_case(UPayloadFormat::Shm; "SHM format")]
+        #[test_case(UPayloadFormat::Someip; "SOMEIP format")]
+        #[test_case(UPayloadFormat::SomeipTlv; "SOMEIP TLV format")]
+        #[test_case(UPayloadFormat::Text; "TEXT format")]
+        #[test_case(UPayloadFormat::Unspecified; "UNSPECIFIED format")]
+        fn test_deserialize_protobuf_bytes_fails_for_(format: UPayloadFormat) {
+            let result = deserialize_protobuf_bytes::<StringValue>("hello".as_bytes(), &format);
+            assert!(result.is_err_and(|e| matches!(e, UMessageError::PayloadError(_))));
+        }
+
+        #[test]
+        fn test_deserialize_protobuf_bytes_fails_for_invalid_encoding() {
+            // GIVEN a protobuf Any message with an embedded Duration message, but with invalid encoding
+            // (i.e. the value field does not contain a valid protobuf encoding of a Duration message)
+            let any = Any {
+                type_url: "type.googleapis.com/google.protobuf.Duration".to_string(),
+                value: vec![0x0A],
+                ..Default::default()
+            };
+            let buf = any.write_to_bytes().unwrap();
+
+            // WHEN deserializing the bytes into a Duration message using the ProtobufWrappedInAny format
+            let result = deserialize_protobuf_bytes::<Duration>(
+                buf.as_slice(),
+                &UPayloadFormat::ProtobufWrappedInAny,
+            );
+            // THEN the deserialization fails with a DataSerializationError
+            assert!(result.is_err_and(|e| matches!(e, UMessageError::DataSerializationError(_))))
+        }
+
+        #[test]
+        fn extract_payload_succeeds() {
+            let payload = StringValue {
+                value: "hello".to_string(),
+                ..Default::default()
+            };
+            let topic = UUri::try_from_parts("local", 0xabcd, 0x01, 0x9000)
+                .expect("failed to create topic");
+            let msg = UMessageBuilder::publish(topic)
+                .build_with_protobuf_payload(&payload)
+                .expect("failed to create message");
+            assert!(msg
+                .extract_protobuf::<StringValue>()
+                .is_ok_and(|v| v.value == *"hello"));
+        }
+
+        #[test]
+        fn extract_payload_fails_for_no_payload() {
+            let topic = UUri::try_from_parts("local", 0xabcd, 0x01, 0x9000)
+                .expect("failed to create topic");
+            let msg = UMessageBuilder::publish(topic)
+                .build()
+                .expect("failed to create message");
+            assert!(msg
+                .extract_protobuf::<StringValue>()
+                .is_err_and(|e| matches!(e, UMessageError::PayloadError(_))));
         }
     }
 }
@@ -398,6 +872,7 @@ mod core_types_support {
     use super::*;
     use crate::up_core_api::uattributes::UAttributes as UAttributesProto;
     use crate::up_core_api::umessage::UMessage as UMessageProto;
+    use crate::ProtobufMappable;
 
     impl From<&UMessage> for UMessageProto {
         fn from(value: &UMessage) -> Self {
@@ -413,14 +888,30 @@ mod core_types_support {
     impl TryFrom<&UMessageProto> for UMessage {
         type Error = UMessageError;
         fn try_from(value: &UMessageProto) -> Result<Self, Self::Error> {
-            let attributes = value.attributes.as_ref().map_or_else(
+            let mut attributes = value.attributes.as_ref().map_or_else(
                 || {
                     Err(UAttributesError::validation_error(
-                        "UMessageProto missing attributes",
+                        "UMessageProto has no attributes",
                     ))
                 },
                 UAttributes::try_from,
             )?;
+            // The uattributes.proto file in up-spec v1.6.0.alpha.7 does not declare the payload_format field
+            // as optional. Consequently, a UMessage protobuf that does not have a payload still ALWAYS has
+            // the UNSPECIFIED payload_format when being deserialized.
+            // When mapping such a message to the (internal) UMessage struct, we therefore need to also consider
+            // whether the message actually has payload or not, in order to set the payload_format field to the
+            // proper value, i.e. Some(Unspecified), if the message has payload, or None otherwise.
+            // This is relevant, because the presence of a payload_format value in the UMessage struct is used to
+            // determine whether the message has payload or not, e.g. when serializing the message back to
+            // protobuf or when extracting the payload as a protobuf message.
+            //
+            // This should no longer be necessary once the payload_format field in uattributes.proto is declared as
+            // optional in the UP specification and the protobuf definitions are updated accordingly.
+            //
+            if value.payload.is_none() {
+                attributes.payload_format = None;
+            }
             UMessage::new(attributes, value.payload.clone())
         }
     }
@@ -458,6 +949,67 @@ mod core_types_support {
                 .and_then(|any| any.write_to_protobuf_bytes())
         }
     }
+
+    #[cfg(test)]
+    mod test {
+        use protobuf::{Enum, EnumOrUnknown};
+
+        use super::*;
+        use crate::up_core_api::uattributes::UAttributes as UAttributesProto;
+        use crate::up_core_api::umessage::UMessage as UMessageProto;
+
+        #[test]
+        fn test_try_from_umessage_proto_fails_for_missing_attributes() {
+            let proto = UMessageProto {
+                attributes: None.into(),
+                ..Default::default()
+            };
+            let result = UMessage::try_from(&proto);
+            assert!(result.is_err_and(|e| matches!(e, UMessageError::AttributesValidationError(_))));
+        }
+
+        #[test_case::test_case(None => None; "for no payload")]
+        #[test_case::test_case(Some("payload") => Some(UPayloadFormat::Unspecified); "for some payload")]
+        fn test_try_from_handles_payload_format(payload: Option<&str>) -> Option<UPayloadFormat> {
+            let valid_attribs_proto = UAttributesProto {
+                type_: EnumOrUnknown::from_i32(
+                    crate::up_core_api::uattributes::UMessageType::UMESSAGE_TYPE_PUBLISH.value(),
+                ),
+                id: Some(crate::up_core_api::uuid::UUID {
+                    msb: 0x0000000000017000_u64,
+                    lsb: 0x8010101010101a1a_u64,
+                    ..Default::default()
+                })
+                .into(),
+                source: Some(crate::up_core_api::uri::UUri {
+                    authority_name: "source".to_string(),
+                    ue_id: 0x0001,
+                    ue_version_major: 0x01,
+                    resource_id: 0x0001,
+                    ..Default::default()
+                })
+                .into(),
+                priority: EnumOrUnknown::from_i32(
+                    crate::up_core_api::uattributes::UPriority::UPRIORITY_UNSPECIFIED.value(),
+                ),
+                payload_format: EnumOrUnknown::from_i32(
+                    crate::up_core_api::uattributes::UPayloadFormat::UPAYLOAD_FORMAT_UNSPECIFIED
+                        .value(),
+                ),
+                ..Default::default()
+            };
+            // GIVEN a UMessageProto with valid attributes (including the UNSPECIFIED payload format) but no payload
+            let proto = UMessageProto {
+                attributes: Some(valid_attribs_proto).into(),
+                payload: payload.map(|p| p.as_bytes().to_vec().into()),
+                ..Default::default()
+            };
+            // WHEN converting the UMessageProto to a UMessage
+            UMessage::try_from(&proto)
+                .expect("failed to convert UMessageProto to UMessage")
+                .payload_format()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -479,118 +1031,5 @@ mod test {
     fn test_from_error_msg() {
         let message_error = UMessageError::from("an error occurred");
         assert!(matches!(message_error, UMessageError::PayloadError(_)));
-    }
-}
-
-#[cfg(all(test, feature = "protobuf-support"))]
-mod protobuf_support_test {
-    use super::*;
-    use crate::UUri;
-    use protobuf::well_known_types::{
-        any::Any,
-        duration::Duration,
-        wrappers::{DoubleValue, StringValue},
-    };
-    use protobuf::Message;
-    use test_case::test_case;
-
-    #[test]
-    fn test_from_protobuf_error() {
-        let protobuf_error = protobuf::Error::from(std::io::Error::last_os_error());
-        let message_error = UMessageError::from(protobuf_error);
-        assert!(matches!(
-            message_error,
-            UMessageError::DataSerializationError(_)
-        ));
-    }
-
-    #[test]
-    fn test_deserialize_protobuf_bytes_succeeds() {
-        let mut data = StringValue::new();
-        data.value = "hello world".to_string();
-
-        let result = deserialize_protobuf_bytes::<StringValue>(
-            &data
-                .write_to_bytes()
-                .expect("Failed to write protobuf bytes"),
-            &UPayloadFormat::Protobuf,
-        );
-        assert!(result.is_ok_and(|v| v.value == *"hello world"));
-
-        let any = Any::pack(&data).expect("Failed to pack Any");
-        let buf: Bytes = any
-            .write_to_bytes()
-            .expect("Failed to write protobuf bytes")
-            .into();
-
-        let result =
-            deserialize_protobuf_bytes::<StringValue>(&buf, &UPayloadFormat::ProtobufWrappedInAny);
-        assert!(result.is_ok_and(|v| v.value == *"hello world"));
-    }
-
-    #[test]
-    fn test_deserialize_protobuf_bytes_fails_for_payload_type_mismatch() {
-        let mut data = StringValue::new();
-        data.value = "hello world".to_string();
-        let any = Any::pack(&data).unwrap();
-        let buf: Bytes = any.write_to_bytes().unwrap().into();
-        let result =
-            deserialize_protobuf_bytes::<DoubleValue>(&buf, &UPayloadFormat::ProtobufWrappedInAny);
-        assert!(result.is_err_and(|e| matches!(e, UMessageError::DataSerializationError(_))));
-    }
-
-    #[test_case(UPayloadFormat::Json; "JSON format")]
-    #[test_case(UPayloadFormat::Raw; "RAW format")]
-    #[test_case(UPayloadFormat::Shm; "SHM format")]
-    #[test_case(UPayloadFormat::Someip; "SOMEIP format")]
-    #[test_case(UPayloadFormat::SomeipTlv; "SOMEIP TLV format")]
-    #[test_case(UPayloadFormat::Text; "TEXT format")]
-    #[test_case(UPayloadFormat::Unspecified; "UNSPECIFIED format")]
-    fn test_deserialize_protobuf_bytes_fails_for_(format: UPayloadFormat) {
-        let result = deserialize_protobuf_bytes::<StringValue>("hello".as_bytes(), &format);
-        assert!(result.is_err_and(|e| matches!(e, UMessageError::PayloadError(_))));
-    }
-
-    #[test]
-    fn test_deserialize_protobuf_bytes_fails_for_invalid_encoding() {
-        let any = Any {
-            type_url: "type.googleapis.com/google.protobuf.Duration".to_string(),
-            value: vec![0x0A],
-            ..Default::default()
-        };
-        let buf = any.write_to_bytes().unwrap();
-        let result = deserialize_protobuf_bytes::<Duration>(
-            buf.as_slice(),
-            &UPayloadFormat::ProtobufWrappedInAny,
-        );
-        assert!(result.is_err_and(|e| matches!(e, UMessageError::DataSerializationError(_))))
-    }
-
-    #[test]
-    fn extract_payload_succeeds() {
-        let payload = StringValue {
-            value: "hello".to_string(),
-            ..Default::default()
-        };
-        let topic =
-            UUri::try_from_parts("local", 0xabcd, 0x01, 0x9000).expect("failed to create topic");
-        let msg = UMessageBuilder::publish(topic)
-            .build_with_protobuf_payload(&payload)
-            .expect("failed to create message");
-        assert!(msg
-            .extract_protobuf::<StringValue>()
-            .is_ok_and(|v| v.value == *"hello"));
-    }
-
-    #[test]
-    fn extract_payload_fails_for_no_payload() {
-        let topic =
-            UUri::try_from_parts("local", 0xabcd, 0x01, 0x9000).expect("failed to create topic");
-        let msg = UMessageBuilder::publish(topic)
-            .build()
-            .expect("failed to create message");
-        assert!(msg
-            .extract_protobuf::<StringValue>()
-            .is_err_and(|e| matches!(e, UMessageError::PayloadError(_))));
     }
 }

--- a/src/umessage/umessagebuilder.rs
+++ b/src/umessage/umessagebuilder.rs
@@ -377,7 +377,7 @@ impl UMessageBuilder<InitialBuilderState> {
             message_type: UMessageType::Response,
             source: request_attributes
                 .sink()
-                .expect("Request attributes must have a sink")
+                .expect("Request attributes must contain a sink")
                 .to_owned(),
             message_id: None,
             sink: Some(request_attributes.source().to_owned()),
@@ -781,10 +781,6 @@ impl UMessageBuilder<RequestBuilderState> {
     ///
     /// The builder.
     ///
-    /// # Panics
-    ///
-    /// * if the message is not an RPC request message
-    ///
     /// # Examples
     ///
     /// ```rust
@@ -816,11 +812,6 @@ impl UMessageBuilder<RequestBuilderState> {
     /// # Returns
     ///
     /// The builder.
-    ///
-    /// # Panics
-    ///
-    /// * if the given level is greater than [`i32::MAX`]
-    /// * if the message is not an RPC request message
     ///
     /// # Examples
     ///
@@ -854,10 +845,6 @@ impl UMessageBuilder<ResponseBuilderState> {
     /// # Returns
     ///
     /// The builder.
-    ///
-    /// # Panics
-    ///
-    /// * if the message is not an RPC response message
     ///
     /// # Examples
     ///

--- a/src/umessage/umessagebuilder.rs
+++ b/src/umessage/umessagebuilder.rs
@@ -21,28 +21,90 @@ use crate::{
     UCode, UMessage, UMessageError, UMessageType, UPayloadFormat, UPriority, UUri, UUID,
 };
 
-/// A builder for creating [`UMessage`]s.
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Represents the type of message being built by a [UMessageBuilder].
+/// This is used to limit the available builder functions and to ensure that the
+/// builder is used in a consistent way.
+/// For example, only a builder for a request message can set the `permission_level` and `token` attributes
+/// and only a builder for a response message can set the `comm_status` and `request_id` attributes.
+/// This is achieved by having different builder state types for each message type and by using the
+/// [BuilderState::merge_into_attributes] function to add the state-specific attributes to the
+/// final message attributes when building the message.
 ///
-/// Messages are being used by a uEntity to inform other entities about the occurrence of events
-/// and/or to invoke service operations provided by other entities.
-pub struct UMessageBuilder {
-    comm_status: Option<UCode>,
-    message_id: Option<UUID>,
-    message_type: UMessageType,
-    payload: Option<Bytes>,
-    payload_format: UPayloadFormat,
+/// _Note_: Only this crate can provide implementations of [Self] because of the dependency
+/// on a sealed trait. This is relevant because otherwise, external crates could add custom
+/// constructor functions to [UMessageBuilder] that return malicious implementations of [Self]
+/// which might produce invalid [UMessage] instances by means of the [Self::merge_into_attributes]
+/// function.
+pub trait BuilderState: sealed::Sealed {
+    fn merge_into_attributes(&self, _attributes: &mut UAttributes) {}
+}
+
+pub struct InitialBuilderState;
+impl sealed::Sealed for InitialBuilderState {}
+impl BuilderState for InitialBuilderState {}
+
+pub struct PublishBuilderState;
+impl sealed::Sealed for PublishBuilderState {}
+impl BuilderState for PublishBuilderState {}
+
+pub struct NotificationBuilderState;
+impl sealed::Sealed for NotificationBuilderState {}
+impl BuilderState for NotificationBuilderState {}
+
+pub struct RequestBuilderState {
     permission_level: Option<u32>,
-    priority: Option<UPriority>,
-    request_id: Option<UUID>,
-    sink: Option<UUri>,
-    source: UUri,
     token: Option<String>,
-    traceparent: Option<String>,
+}
+impl sealed::Sealed for RequestBuilderState {}
+impl BuilderState for RequestBuilderState {
+    fn merge_into_attributes(&self, attributes: &mut UAttributes) {
+        attributes.permission_level = self.permission_level;
+        attributes.token = self.token.clone();
+    }
+}
+
+pub struct ResponseBuilderState {
+    comm_status: Option<UCode>,
+    request_id: UUID,
+}
+impl sealed::Sealed for ResponseBuilderState {}
+impl BuilderState for ResponseBuilderState {
+    fn merge_into_attributes(&self, attributes: &mut UAttributes) {
+        attributes.commstatus = self.comm_status;
+        attributes.reqid = Some(self.request_id.clone());
+    }
+}
+
+struct CommonAttributes {
+    message_type: UMessageType,
+    source: UUri,
+    message_id: Option<UUID>,
+    sink: Option<UUri>,
     ttl: Option<u32>,
+    priority: Option<UPriority>,
+    traceparent: Option<String>,
+    payload_format: Option<UPayloadFormat>,
+    payload: Option<Bytes>,
     validator: Box<dyn UAttributesValidator>,
 }
 
-impl UMessageBuilder {
+/// A builder for creating [`UMessage`]s.
+///
+/// Messages are used by uEntities to inform other entities about the occurrence of events
+/// and/or to invoke service operations provided by other entities.
+///
+/// For each type of message there is a dedicated builder which ensures that only attributes
+/// relevant to that message type are set.
+pub struct UMessageBuilder<S: BuilderState> {
+    common: CommonAttributes,
+    extra: S,
+}
+
+impl UMessageBuilder<InitialBuilderState> {
     /// Gets a builder for creating *publish* messages.
     ///
     /// A publish message is used to notify all interested consumers of an event that has occurred.
@@ -68,23 +130,23 @@ impl UMessageBuilder {
     /// # }
     /// ```
     #[must_use]
-    pub fn publish(topic: UUri) -> UMessageBuilder {
-        UMessageBuilder {
-            comm_status: None,
-            message_id: None,
+    pub fn publish(topic: UUri) -> UMessageBuilder<PublishBuilderState> {
+        let common = CommonAttributes {
             // [impl->dsn~up-attributes-publish-type~1]
             message_type: UMessageType::Publish,
-            payload: None,
-            payload_format: UPayloadFormat::Unspecified,
-            permission_level: None,
-            priority: None,
-            request_id: None,
-            sink: None,
             source: topic,
-            token: None,
-            traceparent: None,
+            message_id: None,
+            sink: None,
             ttl: None,
+            priority: None,
+            traceparent: None,
+            payload_format: None,
+            payload: None,
             validator: Box::new(PublishValidator),
+        };
+        UMessageBuilder {
+            common,
+            extra: PublishBuilderState,
         }
     }
 
@@ -115,23 +177,26 @@ impl UMessageBuilder {
     /// # }
     /// ```
     #[must_use]
-    pub fn notification(origin: UUri, destination: UUri) -> UMessageBuilder {
-        UMessageBuilder {
-            comm_status: None,
-            message_id: None,
+    pub fn notification(
+        origin: UUri,
+        destination: UUri,
+    ) -> UMessageBuilder<NotificationBuilderState> {
+        let common = CommonAttributes {
             // [impl->dsn~up-attributes-notification-type~1]
             message_type: UMessageType::Notification,
-            payload: None,
-            payload_format: UPayloadFormat::Unspecified,
-            permission_level: None,
-            priority: None,
-            request_id: None,
-            sink: Some(destination),
             source: origin,
-            token: None,
-            traceparent: None,
+            message_id: None,
+            sink: Some(destination),
             ttl: None,
+            priority: None,
+            traceparent: None,
+            payload_format: None,
+            payload: None,
             validator: Box::new(NotificationValidator),
+        };
+        UMessageBuilder {
+            common,
+            extra: NotificationBuilderState,
         }
     }
 
@@ -168,23 +233,30 @@ impl UMessageBuilder {
     /// # }
     /// ```
     #[must_use]
-    pub fn request(method_to_invoke: UUri, reply_to_address: UUri, ttl: u32) -> UMessageBuilder {
-        UMessageBuilder {
-            comm_status: None,
-            message_id: None,
+    pub fn request(
+        method_to_invoke: UUri,
+        reply_to_address: UUri,
+        ttl: u32,
+    ) -> UMessageBuilder<RequestBuilderState> {
+        let common = CommonAttributes {
             // [impl->dsn~up-attributes-request-type~1]
             message_type: UMessageType::Request,
-            payload: None,
-            payload_format: UPayloadFormat::Unspecified,
-            permission_level: None,
-            priority: Some(UPriority::CS4),
-            request_id: None,
-            sink: Some(method_to_invoke),
             source: reply_to_address,
-            token: None,
-            traceparent: None,
+            message_id: None,
+            sink: Some(method_to_invoke),
             ttl: Some(ttl),
+            priority: Some(UPriority::CS4),
+            traceparent: None,
+            payload_format: None,
+            payload: None,
             validator: Box::new(RequestValidator),
+        };
+        UMessageBuilder {
+            common,
+            extra: RequestBuilderState {
+                permission_level: None,
+                token: None,
+            },
         }
     }
 
@@ -228,27 +300,30 @@ impl UMessageBuilder {
         reply_to_address: UUri,
         request_id: UUID,
         invoked_method: UUri,
-    ) -> UMessageBuilder {
-        UMessageBuilder {
-            comm_status: None,
-            message_id: None,
+    ) -> UMessageBuilder<ResponseBuilderState> {
+        let common = CommonAttributes {
             // [impl->dsn~up-attributes-response-type~1]
             message_type: UMessageType::Response,
-            payload: None,
-            payload_format: UPayloadFormat::Unspecified,
-            permission_level: None,
-            priority: Some(UPriority::CS4),
-            request_id: Some(request_id),
-            sink: Some(reply_to_address),
             source: invoked_method,
-            token: None,
-            traceparent: None,
+            message_id: None,
+            sink: Some(reply_to_address),
             ttl: None,
+            priority: Some(UPriority::CS4),
+            traceparent: None,
+            payload_format: None,
+            payload: None,
             validator: Box::new(ResponseValidator),
+        };
+        UMessageBuilder {
+            common,
+            extra: ResponseBuilderState {
+                comm_status: None,
+                request_id,
+            },
         }
     }
 
-    /// Gets a builder for creating RPC *response* messages in reply to a *request*.
+    /// Gets a builder for creating an RPC *response* message in reply to a *request*.
     ///
     /// A response message is used to send the outcome of processing a request message
     /// to the original sender of the request message.
@@ -290,40 +365,46 @@ impl UMessageBuilder {
     /// # }
     /// ```
     #[must_use]
-    pub fn response_for_request(request_attributes: &UAttributes) -> UMessageBuilder {
+    pub fn response_for_request(
+        request_attributes: &UAttributes,
+    ) -> UMessageBuilder<ResponseBuilderState> {
         assert!(
             request_attributes.is_request(),
             "Given attributes do not represent a request message"
         );
-        UMessageBuilder {
-            comm_status: None,
-            message_id: None,
+        let common = CommonAttributes {
             // [impl->dsn~up-attributes-response-type~1]
             message_type: UMessageType::Response,
-            payload: None,
-            payload_format: UPayloadFormat::Unspecified,
-            permission_level: None,
-            priority: request_attributes.priority,
-            request_id: Some(request_attributes.id.clone()),
-            sink: Some(request_attributes.source.clone()),
             source: request_attributes
                 .sink()
                 .expect("Request attributes must have a sink")
-                .clone(),
-            token: None,
+                .to_owned(),
+            message_id: None,
+            sink: Some(request_attributes.source().to_owned()),
+            ttl: request_attributes.ttl(),
+            priority: request_attributes.priority(),
             traceparent: None,
-            ttl: request_attributes.ttl,
+            payload_format: None,
+            payload: None,
             validator: Box::new(ResponseValidator),
+        };
+        UMessageBuilder {
+            common,
+            extra: ResponseBuilderState {
+                comm_status: None,
+                request_id: request_attributes.id().to_owned(),
+            },
         }
     }
+}
 
+impl<S: BuilderState> UMessageBuilder<S> {
     /// Sets the message's identifier.
     ///
-    /// Every message must have an identifier. If this function is not used, an identifier will be
-    /// generated and set on the message when one of the `build` functions is called on the
-    /// `UMessageBuilder`.
+    /// Every message must have an identifier. However, if this function is not used, an
+    /// identifier will be generated for the message when one of the `build` functions is called.
     ///
-    /// It's more typical to _not_ use this function, but could have edge case uses.
+    /// This method is mainly useful for implementing tests that include assertions on the message ID.
     ///
     /// # Arguments
     ///
@@ -341,7 +422,6 @@ impl UMessageBuilder {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let topic = UUri::try_from("//my-vehicle/4210/1/B24D")?;
     /// let mut builder = UMessageBuilder::publish(topic);
-    /// builder.with_priority(UPriority::CS2);
     /// let message_one = builder
     ///                     .with_message_id(UUID::build())
     ///                     .build_with_payload("closed", UPayloadFormat::Text)?;
@@ -351,13 +431,12 @@ impl UMessageBuilder {
     ///                     .build_with_payload("open", UPayloadFormat::Text)?;
     /// assert_ne!(message_one.id(), message_two.id());
     /// assert_eq!(message_one.source(), message_two.source());
-    /// assert_eq!(message_one.priority_unchecked(), UPriority::CS2);
-    /// assert_eq!(message_two.priority_unchecked(), UPriority::CS2);
+    /// assert_eq!(message_one.payload_format_unchecked(), message_two.payload_format_unchecked());
     /// # Ok(())
     /// # }
     /// ```
-    pub fn with_message_id(&mut self, message_id: UUID) -> &mut UMessageBuilder {
-        self.message_id = Some(message_id);
+    pub fn with_message_id(&mut self, message_id: UUID) -> &mut Self {
+        self.common.message_id = Some(message_id);
         self
     }
 
@@ -375,10 +454,6 @@ impl UMessageBuilder {
     ///
     /// The builder.
     ///
-    /// # Panics
-    ///
-    /// if the builder is used for creating an RPC message but the given priority is less than CS4.
-    ///
     /// # Examples
     ///
     /// ```rust
@@ -393,19 +468,13 @@ impl UMessageBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn with_priority(&mut self, priority: UPriority) -> &mut UMessageBuilder {
-        // [impl->dsn~up-attributes-request-priority~1]
-        if self.message_type == UMessageType::Request || self.message_type == UMessageType::Response
-        {
-            assert!(priority >= UPriority::CS4)
-        }
-        if !UAttributes::is_default_priority(priority) {
-            // only set priority explicitly if it differs from the default priority
-            self.priority = Some(priority);
+    pub fn with_priority(&mut self, priority: UPriority) -> &mut Self {
+        if UAttributes::is_default_priority(priority) {
+            // no need to explicitly set default priority, as the absence of a
+            // priority attribute on the message will be interpreted as the default priority
+            self.common.priority = None;
         } else {
-            // in all other cases set to UNSPECIFIED which will result in the
-            // priority not being included in the serialized protobuf
-            self.priority = None;
+            self.common.priority = Some(priority);
         }
         self
     }
@@ -438,120 +507,8 @@ impl UMessageBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn with_ttl(&mut self, ttl: u32) -> &mut UMessageBuilder {
-        self.ttl = Some(ttl);
-        self
-    }
-
-    /// Sets the message's authorization token used for TAP.
-    ///
-    /// # Arguments
-    ///
-    /// * `token` - The token.
-    ///
-    /// # Returns
-    ///
-    /// The builder.
-    ///
-    /// # Panics
-    ///
-    /// * if the message is not an RPC request message
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use up_rust::{UMessageBuilder, UMessageType, UPayloadFormat, UPriority, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let method_to_invoke = UUri::try_from("//my-vehicle/4210/5/64AB")?;
-    /// let reply_to_address = UUri::try_from("//my-cloud/BA4C/1/0")?;
-    /// let token = "this-is-my-token";
-    /// let message = UMessageBuilder::request(method_to_invoke, reply_to_address, 5000)
-    ///                     .with_token(token)
-    ///                     .build_with_payload("lock", UPayloadFormat::Text)?;
-    /// assert_eq!(message.token(), Some(token));
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn with_token<T: Into<String>>(&mut self, token: T) -> &mut UMessageBuilder {
-        // [impl->dsn~up-attributes-request-token~1]
-        assert!(self.message_type == UMessageType::Request);
-        self.token = Some(token.into());
-        self
-    }
-
-    /// Sets the message's permission level.
-    ///
-    /// # Arguments
-    ///
-    /// * `level` - The level.
-    ///
-    /// # Returns
-    ///
-    /// The builder.
-    ///
-    /// # Panics
-    ///
-    /// * if the given level is greater than [`i32::MAX`]
-    /// * if the message is not an RPC request message
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use up_rust::{UCode, UMessageBuilder, UPayloadFormat, UPriority, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let method_to_invoke = UUri::try_from("//my-vehicle/4210/5/64AB")?;
-    /// let reply_to_address = UUri::try_from("//my-cloud/BA4C/1/0")?;
-    /// let message = UMessageBuilder::request(method_to_invoke, reply_to_address, 5000)
-    ///                     .with_permission_level(12)
-    ///                     .build_with_payload("lock", UPayloadFormat::Text)?;
-    /// assert_eq!(message.permission_level(), Some(12));
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn with_permission_level(&mut self, level: u32) -> &mut UMessageBuilder {
-        // [impl->dsn~up-attributes-permission-level~1]
-        assert!(self.message_type == UMessageType::Request);
-        self.permission_level = Some(level);
-        self
-    }
-
-    /// Sets the message's communication status.
-    ///
-    /// # Arguments
-    ///
-    /// * `comm_status` - The status.
-    ///
-    /// # Returns
-    ///
-    /// The builder.
-    ///
-    /// # Panics
-    ///
-    /// * if the message is not an RPC response message
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use up_rust::{UCode, UMessageBuilder, UPriority, UUID, UUri};
-    ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let invoked_method = UUri::try_from("//my-vehicle/4210/5/64AB")?;
-    /// let reply_to_address = UUri::try_from("//my-cloud/BA4C/1/0")?;
-    /// let request_msg_id = UUID::build();
-    /// // a service implementation would normally use
-    /// // `UMessageBuilder::response_for_request(&request_message.attributes)` instead
-    /// let message = UMessageBuilder::response(reply_to_address, request_msg_id, invoked_method)
-    ///                     .with_comm_status(UCode::Ok)
-    ///                     .build()?;
-    /// assert_eq!(message.commstatus_unchecked(), UCode::Ok);
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn with_comm_status(&mut self, comm_status: UCode) -> &mut UMessageBuilder {
-        assert!(self.message_type == UMessageType::Response);
-        self.comm_status = Some(comm_status);
+    pub fn with_ttl(&mut self, ttl: u32) -> &mut Self {
+        self.common.ttl = Some(ttl);
         self
     }
 
@@ -579,9 +536,9 @@ impl UMessageBuilder {
     /// assert_eq!(message.traceparent(), Some(traceparent));
     /// # Ok(())
     /// # }
-    pub fn with_traceparent<T: Into<String>>(&mut self, traceparent: T) -> &mut UMessageBuilder {
+    pub fn with_traceparent<T: Into<String>>(&mut self, traceparent: T) -> &mut Self {
         // [impl->dsn~up-attributes-traceparent~1]
-        self.traceparent = Some(traceparent.into());
+        self.common.traceparent = Some(traceparent.into());
         self
     }
 
@@ -641,27 +598,32 @@ impl UMessageBuilder {
     pub fn build(&self) -> Result<UMessage, UMessageError> {
         // [impl->dsn~up-attributes-id~1]
         let message_id = self
+            .common
             .message_id
             .as_ref()
             .map_or_else(UUID::build, |id| id.clone());
-        let attributes = UAttributes {
-            commstatus: self.comm_status,
+        let mut attributes = UAttributes {
+            type_: self.common.message_type,
             id: message_id,
-            payload_format: self.payload_format.into(),
-            permission_level: self.permission_level,
-            priority: self.priority,
-            reqid: self.request_id.clone(),
-            sink: self.sink.clone(),
-            source: self.source.clone(),
-            token: self.token.clone(),
-            traceparent: self.traceparent.clone(),
-            ttl: self.ttl,
-            type_: self.message_type,
+            source: self.common.source.to_owned(),
+            sink: self.common.sink.to_owned(),
+            ttl: self.common.ttl,
+            priority: self.common.priority,
+            traceparent: self.common.traceparent.to_owned(),
+            payload_format: self.common.payload_format,
+            token: None, // token is only relevant for request messages and is set via the RequestBuilderState
+            permission_level: None, // permission_level is only relevant for request messages and is set via the RequestBuilderState
+            commstatus: None, // commstatus is only relevant for response messages and is set via the ResponseBuilderState
+            reqid: None, // reqid is only relevant for response messages and is set via the ResponseBuilderState
         };
-        self.validator
+        // add state-specific attributes
+        self.extra.merge_into_attributes(&mut attributes);
+        // make sure that we have created a valid set of attributes before creating the final message
+        self.common
+            .validator
             .validate(&attributes)
             .map_err(UMessageError::from)
-            .and_then(|_| UMessage::new(attributes, self.payload.clone()))
+            .and_then(|_| UMessage::new(attributes, self.common.payload.clone()))
     }
 
     /// Creates the message based on the builder's state and some payload.
@@ -698,9 +660,9 @@ impl UMessageBuilder {
         payload: T,
         format: UPayloadFormat,
     ) -> Result<UMessage, UMessageError> {
-        self.payload = Some(payload.into());
+        self.common.payload = Some(payload.into());
         // [impl->dsn~up-attributes-payload-format~1]
-        self.payload_format = format;
+        self.common.payload_format = Some(format);
 
         self.build()
     }
@@ -808,6 +770,119 @@ impl UMessageBuilder {
     }
 }
 
+impl UMessageBuilder<RequestBuilderState> {
+    /// Sets the message's authorization token used for TAP.
+    ///
+    /// # Arguments
+    ///
+    /// * `token` - The token.
+    ///
+    /// # Returns
+    ///
+    /// The builder.
+    ///
+    /// # Panics
+    ///
+    /// * if the message is not an RPC request message
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use up_rust::{UMessageBuilder, UMessageType, UPayloadFormat, UPriority, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let method_to_invoke = UUri::try_from("//my-vehicle/4210/5/64AB")?;
+    /// let reply_to_address = UUri::try_from("//my-cloud/BA4C/1/0")?;
+    /// let token = "this-is-my-token";
+    /// let message = UMessageBuilder::request(method_to_invoke, reply_to_address, 5000)
+    ///                     .with_token(token)
+    ///                     .build_with_payload("lock", UPayloadFormat::Text)?;
+    /// assert_eq!(message.token(), Some(token));
+    /// # Ok(())
+    /// # }
+    /// ```
+    // [impl->dsn~up-attributes-request-token~1]
+    pub fn with_token<T: Into<String>>(&mut self, token: T) -> &mut Self {
+        self.extra.token = Some(token.into());
+        self
+    }
+
+    /// Sets the message's permission level.
+    ///
+    /// # Arguments
+    ///
+    /// * `level` - The level.
+    ///
+    /// # Returns
+    ///
+    /// The builder.
+    ///
+    /// # Panics
+    ///
+    /// * if the given level is greater than [`i32::MAX`]
+    /// * if the message is not an RPC request message
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use up_rust::{UCode, UMessageBuilder, UPayloadFormat, UPriority, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let method_to_invoke = UUri::try_from("//my-vehicle/4210/5/64AB")?;
+    /// let reply_to_address = UUri::try_from("//my-cloud/BA4C/1/0")?;
+    /// let message = UMessageBuilder::request(method_to_invoke, reply_to_address, 5000)
+    ///                     .with_permission_level(12)
+    ///                     .build_with_payload("lock", UPayloadFormat::Text)?;
+    /// assert_eq!(message.permission_level(), Some(12));
+    /// # Ok(())
+    /// # }
+    /// ```
+    // [impl->dsn~up-attributes-permission-level~1]
+    pub fn with_permission_level(&mut self, level: u32) -> &mut Self {
+        self.extra.permission_level = Some(level);
+        self
+    }
+}
+
+impl UMessageBuilder<ResponseBuilderState> {
+    /// Sets the message's communication status.
+    ///
+    /// # Arguments
+    ///
+    /// * `comm_status` - The status.
+    ///
+    /// # Returns
+    ///
+    /// The builder.
+    ///
+    /// # Panics
+    ///
+    /// * if the message is not an RPC response message
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use up_rust::{UCode, UMessageBuilder, UPriority, UUID, UUri};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let invoked_method = UUri::try_from("//my-vehicle/4210/5/64AB")?;
+    /// let reply_to_address = UUri::try_from("//my-cloud/BA4C/1/0")?;
+    /// let request_msg_id = UUID::build();
+    /// // a service implementation would normally use
+    /// // `UMessageBuilder::response_for_request(&request_message.attributes)` instead
+    /// let message = UMessageBuilder::response(reply_to_address, request_msg_id, invoked_method)
+    ///                     .with_comm_status(UCode::Ok)
+    ///                     .build()?;
+    /// assert_eq!(message.commstatus_unchecked(), UCode::Ok);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_comm_status(&mut self, comm_status: UCode) -> &mut Self {
+        self.extra.comm_status = Some(comm_status);
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -820,111 +895,30 @@ mod tests {
     const REPLY_TO_ADDRESS: &str = "//my-cloud/9CB3/1/0";
     const TOPIC: &str = "//my-vehicle/4210/1/B24D";
 
-    // [utest->dsn~up-attributes-permission-level~1]
-    #[test_case(Some(5), None, None; "with permission level")]
-    #[test_case(None, Some(UCode::NotFound), None; "with commstatus")]
-    // [utest->dsn~up-attributes-request-token~1]
-    #[test_case(None, None, Some(String::from("my-token")); "with token")]
-    #[should_panic]
-    fn test_publish_message_builder_panics(
-        perm_level: Option<u32>,
-        comm_status: Option<UCode>,
-        token: Option<String>,
-    ) {
-        let topic = UUri::try_from(TOPIC).expect("should have been able to create UUri");
-        let mut builder = UMessageBuilder::publish(topic);
-        if let Some(level) = perm_level {
-            builder.with_permission_level(level);
-        } else if let Some(status_code) = comm_status {
-            builder.with_comm_status(status_code);
-        } else if let Some(t) = token {
-            builder.with_token(t);
-        }
-    }
-
-    // [utest->dsn~up-attributes-permission-level~1]
-    #[test_case(Some(5), None, None; "with permission level")]
-    #[test_case(None, Some(UCode::NotFound), None; "with commstatus")]
-    // [utest->dsn~up-attributes-request-token~1]
-    #[test_case(None, None, Some(String::from("my-token")); "with token")]
-    #[should_panic]
-    fn test_notification_message_builder_panics(
-        perm_level: Option<u32>,
-        comm_status: Option<UCode>,
-        token: Option<String>,
-    ) {
-        let origin = UUri::try_from(TOPIC).expect("should have been able to create UUri");
-        let destination =
-            UUri::try_from(REPLY_TO_ADDRESS).expect("should have been able to create UUri");
-        let mut builder = UMessageBuilder::notification(origin, destination);
-        if let Some(level) = perm_level {
-            builder.with_permission_level(level);
-        } else if let Some(status_code) = comm_status {
-            builder.with_comm_status(status_code);
-        } else if let Some(t) = token {
-            builder.with_token(t);
-        }
-    }
-
-    // [utest->dsn~up-attributes-permission-level~1]
-    #[test_case(Some(5), None, None; "with permission level")]
-    // [utest->dsn~up-attributes-request-token~1]
-    #[test_case(None, Some(String::from("my-token")), None; "with token")]
+    #[test_case(UPriority::CS0; "with priority CS0")]
+    #[test_case(UPriority::CS1; "with priority CS1")]
+    #[test_case(UPriority::CS2; "with priority CS2")]
+    #[test_case(UPriority::CS3; "with priority CS3")]
     // [utest->dsn~up-attributes-request-priority~1]
-    #[test_case(None, None, Some(UPriority::CS0); "with priority CS0")]
-    // [utest->dsn~up-attributes-request-priority~1]
-    #[test_case(None, None, Some(UPriority::CS1); "with priority CS1")]
-    // [utest->dsn~up-attributes-request-priority~1]
-    #[test_case(None, None, Some(UPriority::CS2); "with priority CS2")]
-    // [utest->dsn~up-attributes-request-priority~1]
-    #[test_case(None, None, Some(UPriority::CS3); "with priority CS3")]
-    #[should_panic]
-    fn test_response_message_builder_panics(
-        perm_level: Option<u32>,
-        token: Option<String>,
-        priority: Option<UPriority>,
-    ) {
+    // [utest->dsn~up-attributes-response-priority~1]
+    fn test_rpc_message_builders_fail(priority: UPriority) {
         let request_id = UUID::build();
         let method_to_invoke = UUri::try_from(METHOD_TO_INVOKE)
             .expect("should have been able to create destination UUri");
         let reply_to_address = UUri::try_from(REPLY_TO_ADDRESS)
             .expect("should have been able to create reply-to UUri");
-        let mut builder = UMessageBuilder::response(reply_to_address, request_id, method_to_invoke);
-
-        if let Some(level) = perm_level {
-            builder.with_permission_level(level);
-        } else if let Some(t) = token {
-            builder.with_token(t);
-        } else if let Some(prio) = priority {
-            builder.with_priority(prio);
-        }
-    }
-
-    #[test_case(Some(UCode::NotFound), None; "for comm status")]
-    // [utest->dsn~up-attributes-request-priority~1]
-    #[test_case(None, Some(UPriority::CS0); "for priority class CS0")]
-    // [utest->dsn~up-attributes-request-priority~1]
-    #[test_case(None, Some(UPriority::CS1); "for priority class CS1")]
-    // [utest->dsn~up-attributes-request-priority~1]
-    #[test_case(None, Some(UPriority::CS2); "for priority class CS2")]
-    // [utest->dsn~up-attributes-request-priority~1]
-    #[test_case(None, Some(UPriority::CS3); "for priority class CS3")]
-    #[should_panic]
-    fn test_request_message_builder_panics(
-        comm_status: Option<UCode>,
-        priority: Option<UPriority>,
-    ) {
-        let method_to_invoke = UUri::try_from(METHOD_TO_INVOKE)
-            .expect("should have been able to create destination UUri");
-        let reply_to_address = UUri::try_from(REPLY_TO_ADDRESS)
-            .expect("should have been able to create reply-to UUri");
-        let mut builder = UMessageBuilder::request(method_to_invoke, reply_to_address, 5000);
-
-        if let Some(status) = comm_status {
-            builder.with_comm_status(status);
-        } else if let Some(prio) = priority {
-            builder.with_priority(prio);
-        }
+        assert!(
+            UMessageBuilder::request(method_to_invoke.clone(), reply_to_address.clone(), 5000)
+                .with_priority(priority)
+                .build()
+                .is_err()
+        );
+        assert!(
+            UMessageBuilder::response(reply_to_address, request_id, method_to_invoke)
+                .with_priority(priority)
+                .build()
+                .is_err()
+        );
     }
 
     #[test]
@@ -973,6 +967,10 @@ mod tests {
         // [utest->dsn~up-attributes-payload-format~1]
         assert_eq!(message.payload_format_unchecked(), UPayloadFormat::Text);
 
+        assert!(message.commstatus().is_none());
+        assert!(message.permission_level().is_none());
+        assert!(message.token().is_none());
+
         #[cfg(feature = "up-core-types")]
         {
             // [utest->req~uattributes-data-model-proto~1]
@@ -1015,6 +1013,10 @@ mod tests {
         assert!(message.is_notification());
         // [utest->dsn~up-attributes-payload-format~1]
         assert_eq!(message.payload_format_unchecked(), UPayloadFormat::Text);
+
+        assert!(message.commstatus().is_none());
+        assert!(message.permission_level().is_none());
+        assert!(message.token().is_none());
 
         #[cfg(feature = "up-core-types")]
         {
@@ -1067,6 +1069,9 @@ mod tests {
         // [utest->dsn~up-attributes-payload-format~1]
         assert_eq!(message.payload_format_unchecked(), UPayloadFormat::Text);
 
+        assert!(message.commstatus().is_none());
+        assert!(message.request_id().is_none());
+
         // [utest->req~uattributes-data-model-proto~1]
         // [utest->req~umessage-data-model-proto~1]
         #[cfg(feature = "up-core-types")]
@@ -1078,6 +1083,19 @@ mod tests {
                 .expect("failed to deserialize protobuf");
             assert_eq!(message, deserialized_message);
         }
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_response_for_request_panics_for_non_request_attributes() {
+        let message_id = UUID::build();
+        let topic = UUri::try_from(TOPIC).expect("should have been able to create UUri");
+        let request_message = UMessageBuilder::publish(topic.clone())
+            .with_message_id(message_id.clone())
+            .build()
+            .expect("should have been able to create message");
+
+        let _ = UMessageBuilder::response_for_request(&request_message.attributes).build();
     }
 
     #[test]
@@ -1109,11 +1127,11 @@ mod tests {
         assert_eq!(message.ttl_unchecked(), 5000);
         // [utest->dsn~up-attributes-response-type~1]
         assert!(message.is_response());
-        assert_eq!(
-            message.payload_format_unchecked(),
-            UPayloadFormat::Unspecified
-        );
+        assert!(message.payload_format().is_none());
         assert!(message.payload.is_none());
+
+        assert!(message.permission_level().is_none());
+        assert!(message.token().is_none());
     }
 
     #[test]
@@ -1152,11 +1170,11 @@ mod tests {
         assert_eq!(message.traceparent(), Some(traceparent));
         // [utest->dsn~up-attributes-response-type~1]
         assert!(message.is_response());
-        assert_eq!(
-            message.payload_format_unchecked(),
-            UPayloadFormat::Unspecified
-        );
+        assert!(message.payload_format().is_none());
         assert!(message.payload.is_none());
+
+        assert!(message.permission_level().is_none());
+        assert!(message.token().is_none());
 
         // [utest->req~uattributes-data-model-proto~1]
         // [utest->req~umessage-data-model-proto~1]


### PR DESCRIPTION
Introduced the Typestate pattern for the UMessageBuilder to enforce the correct sequence of method calls when building a UMessage of a particular type.

This change ensures that all required (and only appropriate) fields are set before the message can be built, improving code safety and reducing the likelihood of runtime errors.