### PR TITLE
Fix simple_notify example requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ required-features = ["up-l2-notifier", "util"]
 
 [[example]]
 name = "simple_publish"
-required-features = ["up-l2-publisher", "util"]
+required-features = ["up-l2-publisher", "protobuf-support", "util"]
 
 [[example]]
 name = "simple_rpc"

--- a/examples/simple_notify.rs
+++ b/examples/simple_notify.rs
@@ -13,7 +13,7 @@
 
 use std::sync::Arc;
 
-use protobuf::well_known_types::wrappers::StringValue;
+use bytes::Bytes;
 use up_rust::{
     communication::{CallOptions, Notifier, SimpleNotifier, UPayload},
     local_transport::LocalTransport,
@@ -25,8 +25,9 @@ struct ConsolePrinter {}
 #[async_trait::async_trait]
 impl UListener for ConsolePrinter {
     async fn on_receive(&self, msg: UMessage) {
-        if let Ok(payload) = msg.extract_protobuf::<StringValue>() {
-            println!("received notification: {}", payload.value);
+        if let Some(payload) = msg.payload() {
+            let msg = String::from_utf8_lossy(payload.as_ref());
+            println!("received notification: {}", msg);
         }
     }
 }
@@ -47,11 +48,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     notifier.start_listening(&topic, listener.clone()).await?;
 
-    let value = StringValue {
-        value: "Hello".to_string(),
-        ..Default::default()
-    };
-    let payload = UPayload::try_from_protobuf(value)?;
+    let payload = UPayload::new(Bytes::from("Hello"), up_rust::UPayloadFormat::Text);
     notifier
         .notify(
             ORIGIN_RESOURCE_ID,
@@ -61,6 +58,12 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .await?;
 
+    // At this point we can be sure that all notifications have been processed already.
+    // This is because the LocalTransport dispatches all messages to listeners on the same
+    // thread that has been used to send the messages.
+    // When using an asynchronous transport, such as MQTT5 or Eclipse Zenoh, we would need to
+    // notify the sender from within the listener, e.g. by means of a Channel, before stopping
+    // the listener.
     notifier.stop_listening(&topic, listener).await?;
     Ok(())
 }


### PR DESCRIPTION
Removed code that required the "protobuf-support" feature from the simple_notify example. Added "protobuf-support" to required features of the simple_publish example which illustrates, how protobuf payload can be sent in an event.