### PR TITLE
Remove unneeded Default trait requirement from extract_protobuf

### DIFF
--- a/src/communication.rs
+++ b/src/communication.rs
@@ -437,7 +437,7 @@ impl UPayload {
     #[cfg(feature = "protobuf-support")]
     pub fn extract_protobuf<T>(&self) -> Result<T, crate::UMessageError>
     where
-        T: crate::ProtobufMappable + Default,
+        T: crate::ProtobufMappable,
     {
         crate::umessage::deserialize_protobuf_bytes(&self.payload, &self.payload_format)
     }

--- a/src/communication/rpc.rs
+++ b/src/communication/rpc.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use thiserror::Error;
 
-use crate::{ProtobufMappable, UAttributes, UCode, UStatus, UUri};
+use crate::{UAttributes, UCode, UStatus, UUri};
 
 use super::{CallOptions, RegistrationError, UPayload};
 
@@ -194,7 +194,7 @@ impl dyn RpcClient {
     ///
     /// Returns an error if invocation fails, the given arguments cannot be turned into a valid RPC Request message,
     /// result protobuf deserialization fails, or result payload is empty.
-    pub async fn invoke_proto_method<T: ProtobufMappable, R: ProtobufMappable>(
+    pub async fn invoke_proto_method<T: crate::ProtobufMappable, R: crate::ProtobufMappable>(
         &self,
         method: UUri,
         call_options: CallOptions,

--- a/src/communication/rpc.rs
+++ b/src/communication/rpc.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use thiserror::Error;
 
-use crate::{UAttributes, UCode, UStatus, UUri};
+use crate::{ProtobufMappable, UAttributes, UCode, UStatus, UUri};
 
 use super::{CallOptions, RegistrationError, UPayload};
 
@@ -194,16 +194,12 @@ impl dyn RpcClient {
     ///
     /// Returns an error if invocation fails, the given arguments cannot be turned into a valid RPC Request message,
     /// result protobuf deserialization fails, or result payload is empty.
-    pub async fn invoke_proto_method<T, R>(
+    pub async fn invoke_proto_method<T: ProtobufMappable, R: ProtobufMappable>(
         &self,
         method: UUri,
         call_options: CallOptions,
         request_message: T,
-    ) -> Result<R, ServiceInvocationError>
-    where
-        T: crate::ProtobufMappable,
-        R: crate::ProtobufMappable + Default,
-    {
+    ) -> Result<R, ServiceInvocationError> {
         let payload = UPayload::try_from_protobuf(request_message)
             .map_err(|e| ServiceInvocationError::InvalidArgument(e.to_string()))?;
 


### PR DESCRIPTION
The Default trait requirement for the target type parameter of extract_protobuf functionality isn't actually needed (and is a hindrance for the usubscription v4 work), so removing it. 