### PR TITLE
Move expiration check to UUID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
  "serde_json",
  "symphony",
  "test-case",
- "thiserror 1.0.69",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "uriparse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ protobuf-support = ["dep:protobuf"]
 symphony = ["up-l2-rpc-server", "dep:serde", "dep:serde_json", "dep:symphony"]
 test-util = ["dep:mockall"]
 up-core-types = ["protobuf-support"]
-up-l2-api = ["dep:thiserror"]
+up-l2-api = []
 up-l2-notifier = ["up-l2-api"]
 up-l2-publisher = ["up-l2-api"]
 up-l2-subscriber = ["up-l2-api", "usubscription"]
@@ -68,7 +68,7 @@ regex = { version = "1.13.1", default-features = false, features = ["perf", "std
 serde = { version = "1.0.228", optional = true }
 serde_json = { version = "1.0.150", optional = true }
 symphony = { version = "0.1.5", optional = true }
-thiserror = { version = "1.0.69", optional = true }
+thiserror = { version = "2.0.20" }
 tokio = { version = "1.53.1", default-features = false, optional = true }
 tracing = { version = "0.1.44", default-features = false, features = ["log", "std"] }
 uriparse = { version = "0.6.4" }

--- a/src/uattributes.rs
+++ b/src/uattributes.rs
@@ -16,7 +16,7 @@ mod umessagetype;
 mod upayloadformat;
 mod upriority;
 
-use std::time::SystemTime;
+use thiserror::Error;
 
 pub use uattributesvalidator::*;
 pub use umessagetype::UMessageType;
@@ -30,9 +30,13 @@ pub(crate) const UPRIORITY_DEFAULT: UPriority = UPriority::CS1;
 pub(crate) type TokenString = String;
 pub(crate) type TraceparentString = String;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum UAttributesError {
+    #[error("Validation failure: {0}")]
     ValidationError(String),
+    #[error("Message expired")]
+    ExpiredError,
+    #[error("Parsing error: {0}")]
     ParsingError(String),
 }
 
@@ -51,17 +55,6 @@ impl UAttributesError {
         Self::ParsingError(message.into())
     }
 }
-
-impl std::fmt::Display for UAttributesError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::ValidationError(e) => f.write_fmt(format_args!("Validation failure: {e}")),
-            Self::ParsingError(e) => f.write_fmt(format_args!("Parsing error: {e}")),
-        }
-    }
-}
-
-impl std::error::Error for UAttributesError {}
 
 impl From<UUriError> for UAttributesError {
     fn from(value: UUriError) -> Self {
@@ -290,20 +283,23 @@ impl UAttributes {
     /// Returns an error if [`Self::ttl`] (time-to-live) contains a value greater than 0, but
     /// * the current system time cannot be determined, or
     /// * the message has expired according to the timestamp extracted from [`Self::id`] and the time-to-live value.
+    ///
+    /// # Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use up_rust::{UMessageBuilder, UUri};
+    /// let publish_msg = UMessageBuilder::publish(UUri::try_from("//my-vehicle/D45/1/A001")?)
+    ///     .build()?;
+    /// assert!(publish_msg.attributes().check_expired().is_ok());
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn check_expired(&self) -> Result<(), UAttributesError> {
-        if let Some(ttl) = self.ttl {
-            if ttl == 0 {
-                return Ok(());
-            }
+        if let Some(ttl) = self.ttl() {
+            self.id().check_expired(ttl)
+        } else {
+            Ok(())
         }
-        SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .map_err(|_e| {
-                UAttributesError::validation_error("Cannot determine current system time")
-            })
-            .and_then(|duration_since_epoch| {
-                self.check_expired_for_reference(duration_since_epoch.as_millis())
-            })
     }
 
     /// Checks if the message that is described by these attributes should be considered expired.
@@ -318,19 +314,34 @@ impl UAttributes {
     /// Returns an error if [`Self::ttl`] (time-to-live) contains a value greater than 0, but
     /// the message has expired according to the timestamp extracted from [`Self::id`], the
     /// time-to-live value and the provided reference time.
+    ///
+    /// # Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use std::time::SystemTime;
+    /// use up_rust::{UMessageBuilder, UUri};
+    ///
+    /// let now = SystemTime::now()
+    ///     .duration_since(SystemTime::UNIX_EPOCH)?
+    ///     .as_millis();
+    ///
+    /// let reference_time = now + 300_000; // 5 minutes from now
+    /// let publish_msg = UMessageBuilder::publish(UUri::try_from("//my-vehicle/D45/1/A001")?)
+    ///     .with_ttl(5_000) // Set a TTL of 5 seconds
+    ///     .build()?;
+    /// assert!(publish_msg.attributes().check_expired_for_reference(reference_time).is_err());
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn check_expired_for_reference(
         &self,
         reference_time: u128,
     ) -> Result<(), UAttributesError> {
-        let ttl = match self.ttl {
-            Some(t) if t > 0 => u128::from(t),
-            _ => return Ok(()),
-        };
-
-        if (self.id.get_time() as u128).saturating_add(ttl) <= reference_time {
-            return Err(UAttributesError::validation_error("Message has expired"));
+        if let Some(ttl) = self.ttl() {
+            self.id().check_expired_for_reference(ttl, reference_time)
+        } else {
+            Ok(())
         }
-        Ok(())
     }
 }
 
@@ -542,55 +553,5 @@ mod core_types_support {
             let attribs_proto = mutator(valid_attribs_proto);
             UAttributes::try_from(&attribs_proto).map(|_| ())
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::time::UNIX_EPOCH;
-
-    use super::*;
-    use test_case::test_case;
-
-    /// Creates a UUID for a given creation time offset.
-    ///
-    /// # Note
-    ///
-    /// For internal testing purposes only. For end-users, please use [`UUID::build()`]
-    fn build_for_time_offset(offset_millis: i64) -> UUID {
-        let duration_since_unix_epoch = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("current system time is set to a point in time before UNIX Epoch");
-        let now_as_millis_since_epoch: u64 = u64::try_from(duration_since_unix_epoch.as_millis())
-            .expect("current system time is too far in the future");
-        let creation_timestamp = now_as_millis_since_epoch
-            .checked_add_signed(offset_millis)
-            .unwrap();
-        UUID::build_for_timestamp_millis(creation_timestamp)
-    }
-
-    #[test_case(build_for_time_offset(-1000), None, false; "for past message without TTL")]
-    #[test_case(build_for_time_offset(-1000), Some(0), false; "for past message with TTL 0")]
-    #[test_case(build_for_time_offset(-1000), Some(500), true; "for past message with expired TTL")]
-    #[test_case(build_for_time_offset(-1000), Some(2000), false; "for past message with non-expired TTL")]
-    #[test_case(build_for_time_offset(1000), Some(2000), false; "for future message with TTL")]
-    #[test_case(build_for_time_offset(1000), None, false; "for future message without TTL")]
-    fn test_is_expired(id: UUID, ttl: Option<u32>, should_be_expired: bool) {
-        let attributes = UAttributes {
-            type_: UMessageType::Notification,
-            id,
-            ttl,
-            priority: None,
-            commstatus: None,
-            source: UUri::try_from_parts("source", 0x01, 0x02, 0x9000).unwrap(),
-            sink: None,
-            permission_level: None,
-            token: None,
-            traceparent: None,
-            reqid: None,
-            payload_format: None,
-        };
-
-        assert!(attributes.check_expired().is_err() == should_be_expired);
     }
 }

--- a/src/umessage.rs
+++ b/src/umessage.rs
@@ -12,6 +12,7 @@
  ********************************************************************************/
 
 use bytes::Bytes;
+use thiserror::Error;
 
 #[cfg(all(feature = "up-l2-api", feature = "protobuf-support"))]
 pub(crate) use protobuf_support::deserialize_protobuf_bytes;
@@ -26,28 +27,15 @@ mod umessagebuilder;
 
 pub(crate) type Payload = Bytes;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum UMessageError {
+    #[error("Attributes validation error: {0}")]
     AttributesValidationError(UAttributesError),
+    #[error("Failed to serialize message: {0}")]
     DataSerializationError(SerializationError),
+    #[error("UMessage payload error: {0}")]
     PayloadError(String),
 }
-
-impl std::fmt::Display for UMessageError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::AttributesValidationError(e) => f.write_fmt(format_args!(
-                "Builder state is not consistent with message type: {e}"
-            )),
-            Self::DataSerializationError(e) => {
-                f.write_fmt(format_args!("Failed to serialize payload: {e}"))
-            }
-            Self::PayloadError(e) => f.write_fmt(format_args!("UMessage payload error: {e}")),
-        }
-    }
-}
-
-impl std::error::Error for UMessageError {}
 
 impl From<UAttributesError> for UMessageError {
     fn from(value: UAttributesError) -> Self {
@@ -646,6 +634,17 @@ impl UMessage {
     /// Checks if this message should be considered expired.
     ///
     /// This function simply delegates to [`UAttributes::check_expired`].
+    ///
+    /// # Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use up_rust::{UMessageBuilder, UUri};
+    /// let publish_msg = UMessageBuilder::publish(UUri::try_from("//my-vehicle/D45/1/A001")?)
+    ///     .build()?;
+    /// assert!(publish_msg.check_expired().is_ok());
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn check_expired(&self) -> Result<(), UAttributesError> {
         self.attributes().check_expired()
     }
@@ -658,6 +657,25 @@ impl UMessage {
     ///
     /// * `reference_time` - The reference time as milliseconds since UNIX epoch. The check will
     ///   be performed in relation to this point in time.
+    ///
+    /// # Example
+    /// ```
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// use std::time::SystemTime;
+    /// use up_rust::{UMessageBuilder, UUri};
+    ///
+    /// let now = SystemTime::now()
+    ///     .duration_since(SystemTime::UNIX_EPOCH)?
+    ///     .as_millis();
+    ///
+    /// let reference_time = now + 300_000; // 5 minutes from now
+    /// let publish_msg = UMessageBuilder::publish(UUri::try_from("//my-vehicle/D45/1/A001")?)
+    ///     .with_ttl(5_000) // Set a TTL of 5 seconds
+    ///     .build()?;
+    /// assert!(publish_msg.check_expired_for_reference(reference_time).is_err());
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn check_expired_for_reference(
         &self,
         reference_time: u128,
@@ -985,7 +1003,7 @@ mod core_types_support {
                     authority_name: "source".to_string(),
                     ue_id: 0x0001,
                     ue_version_major: 0x01,
-                    resource_id: 0x0001,
+                    resource_id: 0x8001,
                     ..Default::default()
                 })
                 .into(),
@@ -1006,7 +1024,8 @@ mod core_types_support {
             };
             // WHEN converting the UMessageProto to a UMessage
             UMessage::try_from(&proto)
-                .expect("failed to convert UMessageProto to UMessage")
+                // THEN conversion succeeds
+                .expect("Failed to create UMessage from protobuf")
                 .payload_format()
         }
     }

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -18,6 +18,8 @@ use std::{hash::Hash, str::FromStr};
 
 use uuid_simd::{AsciiCase, Out};
 
+use crate::UAttributesError;
+
 const BITMASK_VERSION: u64 = 0b1111 << 12;
 const VERSION_7: u64 = 0b0111 << 12;
 const BITMASK_VARIANT: u64 = 0b11 << 62;
@@ -238,6 +240,60 @@ impl UUID {
     pub fn get_time(&self) -> u64 {
         // the timestamp is contained in the 48 most significant bits
         self.msb >> 16
+    }
+
+    /// Checks if this UUID should be considered expired.
+    ///
+    /// # Arguments
+    /// * `ttl` - The time-to-live value for the UUID, in milliseconds.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the time-to-live is greater than 0, but
+    /// * the current system time cannot be determined, or
+    /// * the timestamp extracted from this UUID plus the time-to-live value
+    ///   is less than or equal to the current system time.
+    pub fn check_expired(&self, ttl: u32) -> Result<(), UAttributesError> {
+        // messages with a TTL of 0 are considered to never expire, so we can skip the check in that case
+        if ttl == 0 {
+            return Ok(());
+        }
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map_err(|_| {
+                UAttributesError::validation_error(
+                    "current system time is set to a point in time before UNIX Epoch",
+                )
+            })?
+            .as_millis();
+        self.check_expired_for_reference(ttl, now)
+    }
+
+    /// Checks if this UUID should be considered expired.
+    ///
+    /// # Arguments
+    /// * `ttl` - The time-to-live value for the UUID, in milliseconds.
+    /// * `reference_time` - The reference time to use for the expiration check, in milliseconds since UNIX EPOCH.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the time-to-live is greater than 0, but
+    /// * the current system time cannot be determined, or
+    /// * the timestamp extracted from this UUID plus the time-to-live value
+    ///   is less than or equal to the given reference time.
+    pub fn check_expired_for_reference(
+        &self,
+        ttl: u32,
+        reference_time: u128,
+    ) -> Result<(), UAttributesError> {
+        // messages with a TTL of 0 are considered to never expire, so we can skip the check in that case
+        if ttl == 0 {
+            return Ok(());
+        }
+        if (self.get_time() as u128).saturating_add(ttl as u128) <= reference_time {
+            return Err(UAttributesError::ExpiredError);
+        }
+        Ok(())
     }
 }
 
@@ -463,7 +519,10 @@ impl FromStr for UUID {
 #[cfg(test)]
 mod tests {
 
+    use std::time::UNIX_EPOCH;
+
     use super::*;
+    use test_case::test_case;
 
     // [utest->dsn~uuid-spec~1]
     // [utest->req~uuid-type~1]
@@ -523,5 +582,29 @@ mod tests {
 
         assert_eq!(String::from(&uuid), "00000000-0001-7000-8010-101010101a1a");
         assert_eq!(String::from(uuid), "00000000-0001-7000-8010-101010101a1a");
+    }
+
+    fn build_for_time_offset(offset_millis: i64) -> UUID {
+        let duration_since_unix_epoch = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("current system time is set to a point in time before UNIX Epoch");
+        let now_as_millis_since_epoch: u64 = u64::try_from(duration_since_unix_epoch.as_millis())
+            .expect("current system time is too far in the future");
+        let creation_timestamp = now_as_millis_since_epoch
+            .checked_add_signed(offset_millis)
+            .unwrap();
+        UUID::build_for_timestamp_millis(creation_timestamp)
+    }
+    #[test_case(build_for_time_offset(-1000), 0 => false; "for past message with TTL 0")]
+    #[test_case(build_for_time_offset(-1000), 500 => true; "for past message with expired TTL")]
+    #[test_case(build_for_time_offset(-1000), 2000 => false; "for past message with non-expired TTL")]
+    #[test_case(build_for_time_offset(1000), 2000 => false; "for future message with TTL")]
+    fn test_is_expired(id: UUID, ttl: u32) -> bool {
+        if id.check_expired(ttl).is_ok() {
+            false
+        } else {
+            id.check_expired(ttl)
+                .is_err_and(|e| matches!(e, UAttributesError::ExpiredError))
+        }
     }
 }


### PR DESCRIPTION
The logic for checking if a message has expired has been moved to the UUID struct. This allows for a more centralized and consistent way of checking expiration across different parts of the codebase, in particular out of the context of existing UAttributes and UMessage structs.