### PR TITLE
Add validation step to UMessage constructor

### DIFF
--- a/src/cloudevents.rs
+++ b/src/cloudevents.rs
@@ -20,8 +20,8 @@
 // [impl->dsn~cloudevents-umessage-mapping~2]
 
 use crate::{
-    UAttributes, UAttributesError, UAttributesValidators, UCode, UMessage, UMessageError,
-    UMessageType, UPayloadFormat, UPriority, UUri, UUID,
+    UAttributes, UAttributesError, UCode, UMessage, UMessageError, UMessageType, UPayloadFormat,
+    UPriority, UUri, UUID,
 };
 use bytes::Bytes;
 use protobuf::well_known_types::any::Any;
@@ -417,7 +417,6 @@ impl TryFrom<CloudEvent> for UMessage {
             traceparent: event.get_traceparent()?,
             payload_format: Some(event.get_payload_format()?),
         };
-        UAttributesValidators::get_validator_for_attributes(&attributes).validate(&attributes)?;
 
         let payload = if event.has_binary_data() {
             Some(Bytes::copy_from_slice(event.binary_data()))
@@ -429,6 +428,7 @@ impl TryFrom<CloudEvent> for UMessage {
             None
         };
 
+        // this will also validate the attributes and return an error if they are not valid
         UMessage::new(attributes, payload)
     }
 }

--- a/src/protobuf_mappable.rs
+++ b/src/protobuf_mappable.rs
@@ -26,6 +26,7 @@ pub trait ProtobufMappable: Sized {
     ///
     /// Returns an error if the given bytes cannot be parsed as a protobuf.
     fn parse_from_protobuf_bytes(proto: &[u8]) -> Result<Self, SerializationError>;
+
     /// Parses an instance of this type from the given packed protobuf bytes.
     ///
     /// # Arguments
@@ -37,12 +38,14 @@ pub trait ProtobufMappable: Sized {
     /// Returns an error if the given bytes cannot be parsed to a protobuf _Any_ message
     /// or if the contained message cannot be unpacked to the expected type.
     fn parse_from_packed_protobuf_bytes(proto: &[u8]) -> Result<Self, SerializationError>;
+
     /// Serializes this instance to protobuf bytes.
     ///
     /// # Errors
     ///
     /// Returns an error if this instance cannot be serialized to protobuf bytes.
     fn write_to_protobuf_bytes(&self) -> Result<Vec<u8>, SerializationError>;
+
     /// Serializes this instance to packed protobuf bytes.
     ///
     /// # Errors

--- a/src/umessage.rs
+++ b/src/umessage.rs
@@ -19,8 +19,8 @@ pub(crate) use protobuf_support::deserialize_protobuf_bytes;
 pub use umessagebuilder::*;
 
 use crate::{
-    SerializationError, UAttributes, UAttributesError, UCode, UMessageType, UPayloadFormat,
-    UPriority, UUri, UUID,
+    SerializationError, UAttributes, UAttributesError, UAttributesValidators, UCode, UMessageType,
+    UPayloadFormat, UPriority, UUri, UUID,
 };
 
 mod umessagebuilder;
@@ -76,17 +76,62 @@ pub struct UMessage {
 }
 
 impl UMessage {
-    // This convenience constructor is used internally only, e.g. by the UMessageBuilder for creating
-    // the final message after validation.
-    // Client code can create UMessages using the UMessageBuilder only.
+    /// This convenience constructor is used internally only, e.g. by the [crate::UMessageBuilder] for creating
+    /// the final message after validation.
+    ///
+    /// Client code can only create UMessages using the [crate::UMessageBuilder] or by deserializing and mapping a
+    /// protobuf. Both of these approaches use this constructor and will therefore validate the message before
+    /// returning it to client code.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the given attributes and payload fail [validation](Self::validate).
     pub(crate) fn new(
         attributes: UAttributes,
         payload: Option<Bytes>,
     ) -> Result<Self, UMessageError> {
-        Ok(UMessage {
+        let msg = UMessage {
             attributes,
             payload,
-        })
+        };
+        msg.validate()?;
+        Ok(msg)
+    }
+
+    /// Validates this message's attributes and payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the message's attributes are [invalid](crate::UAttributesValidator::validate)
+    /// or are not consistent with the message's payload, e.g. the message has a payload format but no
+    /// payload or vice versa.
+    ///
+    /// # Example
+    /// ```
+    /// use up_rust::{UMessageBuilder, UUri, UPayloadFormat};
+    ///
+    /// let topic = UUri::try_from("//my-vehicle/D45/23/A001").unwrap();
+    /// let msg = UMessageBuilder::publish(topic.clone()).build().unwrap();
+    /// assert!(msg.validate().is_ok());
+    ///
+    /// let msg = UMessageBuilder::publish(topic).build_with_payload("Hello", UPayloadFormat::Text).unwrap();
+    /// assert!(msg.validate().is_ok());
+    /// ```
+    pub fn validate(&self) -> Result<(), UMessageError> {
+        UAttributesValidators::get_validator_for_attributes(&self.attributes)
+            .validate(&self.attributes)?;
+        // [impl->dsn~up-attributes-payload-format~1]
+        if self.attributes.payload_format().is_some() && self.payload.is_none() {
+            return Err(UMessageError::PayloadError(
+                "Message has payload format but no payload".to_string(),
+            ));
+        }
+        if self.attributes.payload_format().is_none() && self.payload.is_some() {
+            return Err(UMessageError::PayloadError(
+                "Message has payload but no payload format".to_string(),
+            ));
+        }
+        Ok(())
     }
 
     /// Get this message's attributes.

--- a/src/umessage/umessagebuilder.rs
+++ b/src/umessage/umessagebuilder.rs
@@ -13,12 +13,11 @@
 
 use bytes::Bytes;
 
-use crate::uattributes::NotificationValidator;
 #[cfg(feature = "protobuf-support")]
 use crate::ProtobufMappable;
 use crate::{
-    PublishValidator, RequestValidator, ResponseValidator, UAttributes, UAttributesValidator,
-    UCode, UMessage, UMessageError, UMessageType, UPayloadFormat, UPriority, UUri, UUID,
+    UAttributes, UCode, UMessage, UMessageError, UMessageType, UPayloadFormat, UPriority, UUri,
+    UUID,
 };
 
 mod sealed {
@@ -89,7 +88,6 @@ struct CommonAttributes {
     traceparent: Option<String>,
     payload_format: Option<UPayloadFormat>,
     payload: Option<Bytes>,
-    validator: Box<dyn UAttributesValidator>,
 }
 
 /// A builder for creating [`UMessage`]s.
@@ -142,7 +140,6 @@ impl UMessageBuilder<InitialBuilderState> {
             traceparent: None,
             payload_format: None,
             payload: None,
-            validator: Box::new(PublishValidator),
         };
         UMessageBuilder {
             common,
@@ -192,7 +189,6 @@ impl UMessageBuilder<InitialBuilderState> {
             traceparent: None,
             payload_format: None,
             payload: None,
-            validator: Box::new(NotificationValidator),
         };
         UMessageBuilder {
             common,
@@ -249,7 +245,6 @@ impl UMessageBuilder<InitialBuilderState> {
             traceparent: None,
             payload_format: None,
             payload: None,
-            validator: Box::new(RequestValidator),
         };
         UMessageBuilder {
             common,
@@ -312,7 +307,6 @@ impl UMessageBuilder<InitialBuilderState> {
             traceparent: None,
             payload_format: None,
             payload: None,
-            validator: Box::new(ResponseValidator),
         };
         UMessageBuilder {
             common,
@@ -386,7 +380,6 @@ impl UMessageBuilder<InitialBuilderState> {
             traceparent: None,
             payload_format: None,
             payload: None,
-            validator: Box::new(ResponseValidator),
         };
         UMessageBuilder {
             common,
@@ -618,12 +611,8 @@ impl<S: BuilderState> UMessageBuilder<S> {
         };
         // add state-specific attributes
         self.extra.merge_into_attributes(&mut attributes);
-        // make sure that we have created a valid set of attributes before creating the final message
-        self.common
-            .validator
-            .validate(&attributes)
-            .map_err(UMessageError::from)
-            .and_then(|_| UMessage::new(attributes, self.common.payload.clone()))
+        // finally, create the message, this also includes message validation
+        UMessage::new(attributes, self.common.payload.clone())
     }
 
     /// Creates the message based on the builder's state and some payload.


### PR DESCRIPTION
Added a validation step to the crate internal UMessage constructor. This ensures that any UMessage created through the constructor will be validated for correctness.